### PR TITLE
some fixes + implemented AFC

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,19 +21,19 @@ FFT = hello_fft/hello_fft.a
 ifeq ($(PLATFORM), rpiv1)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp
-  LDLIBS += -lbcm_host
+  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -ffast-math 
+  LDLIBS += -lbcm_host -ldl
   export LDFLAGS = -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_vfp.o
 else ifeq ($(PLATFORM), rpiv2)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
-  LDLIBS += -lbcm_host
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
+  LDLIBS += -lbcm_host -ldl
   export LDFLAGS = -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_neon.o
 else ifeq ($(PLATFORM), armv7-generic)
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), x86)

--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -153,6 +153,10 @@ devices = (
 # Set this to false if you want to skip silence (record only when squelch is open).
 # Default is false.
             continuous = true;
+# Set this to true if you want to append to file if its exists with demarkation of missing fragment.
+# Set this to false if you want to overwrite existing files.
+# Default is false.
+            append = false;
           }
 	);
       },

--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -155,7 +155,7 @@ devices = (
             continuous = true;
 # Set this to true if you want to append to file if its exists with demarkation of missing fragment.
 # Set this to false if you want to overwrite existing files.
-# Default is false.
+# Default is true.
             append = false;
           }
 	);

--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -83,7 +83,7 @@ devices = (
 
 #Automatioc Frequency Control (AFC) level (optional value)
 #0 - disabled (by default)
-#value from range 1...255 - AGC enabled, larger value means more aggressive AGC
+#value from range 1...255 - AFC enabled, larger value means more aggressive AFC
         afc = 0;
 # Multiple outputs per channel are supported. For example, a single channel
 # can be sent to multiple Shoutcast servers.

--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -83,7 +83,7 @@ devices = (
 
 #Automatioc Frequency Control (AFC) level (optional value)
 #0 - disabled (by default)
-#value from range 1...255 - AFC enabled, larger value means more aggressive AFC
+#value from range 1...10 - AFC enabled, larger value means more aggressive AFC.
         afc = 0;
 # Multiple outputs per channel are supported. For example, a single channel
 # can be sent to multiple Shoutcast servers.

--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -80,6 +80,11 @@ devices = (
 # (ie. +- 1.25 MHz around center frequency)
 # This setting is valid in multichannel mode only.
         freq = 118925000;
+
+#Automatioc Frequency Control (AFC) level (optional value)
+#0 - disabled (by default)
+#value from range 1...255 - AGC enabled, larger value means more aggressive AGC
+        afc = 0;
 # Multiple outputs per channel are supported. For example, a single channel
 # can be sent to multiple Shoutcast servers.
         outputs = (

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -537,8 +537,13 @@ static int fdata_open(file_data *fdata, const char *filename) {
     if (fdata->continuous) {
         time_t now = time(NULL);
         if (now > st.st_mtime ) {
+            time_t delta = now - st.st_mtime;
+            if (delta > 3600) {
+                log(LOG_WARNING, "Too big time difference: %llu sec, limiting to one hour\n", (unsigned long long)delta);
+                delta = 3600;
+            }
             LameTone lt_silence(1000);
-            for (time_t delta = now - st.st_mtime; (r==0 && delta > 4); --delta)
+            for (; (r==0 && delta > 1); --delta)
                 r = lt_silence.write(fdata->f);
         }
     }

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -469,7 +469,7 @@ public:
              const float sample_time = 1.0 / (float)WAVE_RATE;
              float t = 0;
              for (int i = 0; i < samples; ++i, t+= sample_time) {
-                 buf[i] = sin(t * 2.0 * M_PI / period);
+                 buf[i] = 0.9 * sinf(t * 2.0 * M_PI / period);
              }
          } else
              memset(buf, 0, samples * sizeof(float));
@@ -527,9 +527,9 @@ static int fdata_open(file_data *fdata, const char *filename) {
     log(LOG_INFO, "Appending from pos %llu to %s\n", (unsigned long long)st.st_size, filename);
 
     //fill missing space with marker tones
-    LameTone lt_a(250, 2222);
-    LameTone lt_b(500, 1111);
-    LameTone lt_c(1000, 555);
+    LameTone lt_a(120, 2222);
+    LameTone lt_b(120, 1111);
+    LameTone lt_c(120, 555);
 
     int r = lt_a.write(fdata->f);
     if (r==0) r = lt_b.write(fdata->f);
@@ -1271,7 +1271,7 @@ int main(int argc, char* argv[]) {
                         fdata->prefix = strdup(devs[i]["channels"][j]["outputs"][o]["filename_template"]);
                         fdata->continuous = devs[i]["channels"][j]["outputs"][o].exists("continuous") ?
                             (bool)(devs[i]["channels"][j]["outputs"][o]["continuous"]) : false;
-                        fdata->append = devs[i]["channels"][j]["outputs"][o].exists("append") && (bool)(devs[i]["channels"][j]["outputs"][o]["append"]);
+                        fdata->append = (!devs[i]["channels"][j]["outputs"][o].exists("append")) || (bool)(devs[i]["channels"][j]["outputs"][o]["append"]);
                     } else {
                         cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"] outputs["<<o<<"]: unknown output type\n";
                         error();

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -534,11 +534,13 @@ static int fdata_open(file_data *fdata, const char *filename) {
     int r = lt_a.write(fdata->f);
     if (r==0) r = lt_b.write(fdata->f);
     if (r==0) r = lt_c.write(fdata->f);
-    time_t now = time(NULL);
-    if (now > st.st_mtime ) {
-        LameTone lt_silence(1000);
-        for (time_t delta = now - st.st_mtime; (r==0 && delta > 4); --delta)
-            r = lt_silence.write(fdata->f);
+    if (fdata->continuous) {
+        time_t now = time(NULL);
+        if (now > st.st_mtime ) {
+            LameTone lt_silence(1000);
+            for (time_t delta = now - st.st_mtime; (r==0 && delta > 4); --delta)
+                r = lt_silence.write(fdata->f);
+        }
     }
     if (r==0) r = lt_c.write(fdata->f);
     if (r==0) r = lt_b.write(fdata->f);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -123,13 +123,13 @@ struct sample_fft_arg
 };
 extern "C" void samplefft(sample_fft_arg *a, unsigned char* buffer, float* window, float* levels);
 
-#include <arm_neon.h>
-
 # define FFT_BATCH 250
 #else
 # define FFT_BATCH 1
 #endif
 #define FFT_SIZE (2<<(FFT_SIZE_LOG - 1))
+
+//#define AFC_LOGGING
 
 #if defined _WIN32
 #pragma comment (lib, "Ws2_32.lib")
@@ -663,7 +663,9 @@ public:
                 bin = check<FFT_RESULTS, 1>(fft_results, base, base_value, channel->afc);
 
              if (dev->bins[index] != bin) {
+#ifdef AFC_LOGGING
                  log(LOG_INFO, "AFC device=%d channel=%d: base=%d prev=%d now=%d\n", dev->device, index, base, dev->bins[index], bin);
+#endif
                  dev->bins[index] = bin;
                  if ( bin > base )
                      channel->axcindicate = '>';

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -30,7 +30,6 @@
 #define _USE_MATH_DEFINES
 #include <SDKDDKVer.h>
 #include <windows.h>
-#include <time.h>
 #include <process.h>
 #include <complex>
 #include <MMSystem.h>
@@ -941,7 +940,7 @@ void demodulate() {
 }
 
 void usage() {
-    cout<<"Usage: rtl_airband [-f] [-p] [-c <config_file_path>]\n\
+    cout<<"Usage: rtl_airband [-f] [-c <config_file_path>]\n\
 \t-h\t\t\tDisplay this help text\n\
 \t-f\t\t\tRun in foreground, display textual waterfalls\n\
 \t-c <config_file_path>\tUse non-default configuration file\n\t\t\t\t(default: "<<CFGFILE<<")\n\

--- a/rtl_airband_neon.s
+++ b/rtl_airband_neon.s
@@ -23,15 +23,19 @@
 .align  2
 .global samplefft
 .type samplefft, %function
-.global fftwave
-.type fftwave, %function
 .fpu    neon
 
 samplefft:
  
 push {r4-r12, lr}
 vpush {d4-d15}
-mov r4, #128
+
+#r0 is sample_fft_arg
+#[r0, #0] is fft_size_by4
+#[r0, #4] is dest
+ldr r4, [r0]
+ldr r0, [r0, #4]
+
 ldrb r5, [r1]
 ldrb r6, [r1, #1]
 ldrb r7, [r1, #2]
@@ -79,123 +83,3 @@ vpop {d4-d15}
 pop {r4-r12, pc}
 
 
-fftwave:
-
-push {r4-r12, lr}
-vpush {d4-d15}
-
-#r2 is int[2]
-#[r2, #0] is fftstep
-#[r2, #4] is wavestep
-ldr r12, [r2, #4]
-ldr r2, [r2]
-ldmia r3, {r4-r11}
-mov r3, #8
-mla r4, r3, r4, r1
-mla r5, r3, r5, r1
-mla r6, r3, r6, r1
-mla r7, r3, r7, r1
-mla r8, r3, r8, r1
-mla r9, r3, r9, r1
-mla r10, r3, r10, r1
-mla r11, r3, r11, r1
-mov r3, #250
-
-.b:
-
-vldr s8, [r4]
-vldr s9, [r5]
-vldr s10, [r6]
-vldr s11, [r7]
-vldr s12, [r8]
-vldr s13, [r9]
-vldr s14, [r10]
-vldr s15, [r11]
-vldr s16, [r4, #4]
-vldr s17, [r5, #4]
-vmul.f32 q2, q2, q2
-vmul.f32 q3, q3, q3
-vldr s18, [r6, #4]
-vldr s19, [r7, #4]
-vldr s20, [r8, #4]
-vldr s21, [r9, #4]
-vldr s22, [r10, #4]
-vldr s23, [r11, #4]
-vldr s24, [r4, #8]
-vldr s25, [r5, #8]
-vmul.f32 q4, q4, q4
-vmul.f32 q5, q5, q5
-vldr s26, [r6, #8]
-vldr s27, [r7, #8]
-vldr s28, [r8, #8]
-vldr s29, [r9, #8]
-vldr s30, [r10, #8]
-vldr s31, [r11, #8]
-vadd.f32 q2, q2, q4
-vadd.f32 q3, q3, q5
-# vrsqrte returns 1/sqrt(x), so we do 1/x (vrecpe) on result
-vrsqrte.f32 q2, q2
-vrecpe.f32 q2, q2
-vrsqrte.f32 q3, q3
-vrecpe.f32 q3, q3
-vldr s16, [r4, #12]
-vldr s17, [r5, #12]
-vldr s18, [r6, #12]
-vldr s19, [r7, #12]
-vldr s20, [r8, #12]
-vldr s21, [r9, #12]
-vldr s22, [r10, #12]
-vldr s23, [r11, #12]
-vmul.f32 q6, q6, q6
-vmul.f32 q7, q7, q7
-vmul.f32 q4, q4, q4
-vmul.f32 q5, q5, q5
-add r4, r2, r4
-add r5, r2, r5
-add r6, r2, r6
-add r7, r2, r7
-add r8, r2, r8
-add r9, r2, r9
-vadd.f32 q4, q4, q6
-vadd.f32 q5, q5, q5
-vrsqrte.f32 q4, q4
-vrecpe.f32 q4, q4
-vrsqrte.f32 q5, q5
-vrecpe.f32 q5, q5
-add r10, r2, r10
-add r11, r2, r11
-pld [r4]
-pld [r5]
-pld [r6]
-pld [r7]
-pld [r8]
-pld [r9]
-pld [r10]
-pld [r11]
-push {r4-r11}
-mov r4, r0
-add r5, r4, r12
-add r6, r5, r12
-add r7, r6, r12
-add r8, r7, r12
-add r9, r8, r12
-add r10, r9, r12
-add r11, r10, r12
-vadd.f32 q2, q2, q4
-vadd.f32 q5, q5, q5
-vstr s8, [r4]
-vstr s9, [r5]
-vstr s10, [r6]
-vstr s11, [r7]
-vstr s12, [r8]
-vstr s13, [r9]
-vstr s14, [r10]
-vstr s15, [r11]
-
-pop {r4-r11}
-add r0, r0, #4
-subs r3, r3, #1
-bne .b
-
-vpop {d4-d15}
-pop {r4-r12, pc}

--- a/rtl_airband_vfp.s
+++ b/rtl_airband_vfp.s
@@ -21,8 +21,6 @@
 .align  2
 .global samplefft
 .type samplefft, %function
-.global fftwave
-.type fftwave, %function
 .fpu    vfp
 
 samplefft:
@@ -35,8 +33,12 @@ bic r4, #0x00370000
 orr r4, #0x00070000
 fmxr fpscr, r4
 
-mov r4, #128
- 
+#r0 is sample_fft_arg
+#[r0, #0] is fft_size_by4
+#[r0, #4] is dest
+ldr r4, [r0]
+ldr r0, [r0, #4]
+
 ldrb r5, [r1]
 ldrb r6, [r1, #1]
 ldrb r7, [r1, #2]
@@ -87,118 +89,3 @@ fldmias sp!, {s8-s31}
 pop {r4-r12, pc}
 
 
-fftwave:
-
-push {r4-r12, lr}
-fstmdbs sp!, {s8-s31}
-
-fmrx r11, fpscr
-bic r11, #0x00370000
-orr r11, #0x00070000
-fmxr fpscr, r11
-
-#r2 is int[2]
-#[r2, #0] is fftstep
-#[r2, #4] is wavestep
-ldr r12, [r2, #4]
-ldr r2, [r2]
-ldmia r3, {r4-r11}
-mov r3, #8
-mla r4, r3, r4, r1
-mla r5, r3, r5, r1
-mla r6, r3, r6, r1
-mla r7, r3, r7, r1
-mla r8, r3, r8, r1
-mla r9, r3, r9, r1
-mla r10, r3, r10, r1
-mla r11, r3, r11, r1
-mov r3, #250
-
-.b:
-
-flds s8, [r4]
-flds s9, [r5]
-flds s10, [r6]
-flds s11, [r7]
-flds s12, [r8]
-flds s13, [r9]
-flds s14, [r10]
-flds s15, [r11]
-flds s16, [r4, #4]
-flds s17, [r5, #4]
-fmuls s8, s8, s8
-flds s18, [r6, #4]
-flds s19, [r7, #4]
-flds s20, [r8, #4]
-flds s21, [r9, #4]
-flds s22, [r10, #4]
-flds s23, [r11, #4]
-flds s24, [r4, #8]
-flds s25, [r5, #8]
-fmuls s16, s16, s16
-flds s26, [r6, #8]
-flds s27, [r7, #8]
-flds s28, [r8, #8]
-flds s29, [r9, #8]
-flds s30, [r10, #8]
-flds s31, [r11, #8]
-fadds s8, s8, s16
-fsqrts s8, s8
-flds s16, [r4, #12]
-flds s17, [r5, #12]
-flds s18, [r6, #12]
-flds s19, [r7, #12]
-flds s20, [r8, #12]
-flds s21, [r9, #12]
-flds s22, [r10, #12]
-flds s23, [r11, #12]
-fmuls s24, s24, s24
-fmuls s16, s16, s16
-add r4, r2, r4
-add r5, r2, r5
-add r6, r2, r6
-add r7, r2, r7
-add r8, r2, r8
-add r9, r2, r9
-fadds s16, s16, s24
-fsqrts s16, s16
-add r10, r2, r10
-add r11, r2, r11
-pld [r4]
-pld [r5]
-pld [r6]
-pld [r7]
-pld [r8]
-pld [r9]
-pld [r10]
-pld [r11]
-push {r4-r11}
-mov r4, r0
-add r5, r4, r12
-add r6, r5, r12
-add r7, r6, r12
-add r8, r7, r12
-add r9, r8, r12
-add r10, r9, r12
-add r11, r10, r12
-fadds s8, s8, s16
-fsts s8, [r4]
-fsts s9, [r5]
-fsts s10, [r6]
-fsts s11, [r7]
-fsts s12, [r8]
-fsts s13, [r9]
-fsts s14, [r10]
-fsts s15, [r11]
-
-pop {r4-r11}
-add r0, r0, #4
-subs r3, r3, #1
-bne .b
-
-fmrx r4, fpscr
-bic r4, #0x00370000
-fmxr fpscr, r4
-
-fldmias sp!, {s8-s31}
-pop {r4-r12, pc}


### PR DESCRIPTION
Fixed several issues: race condition on initialization, RPI compilations with FFT sizes different  than 512.
Implemented Automatic Frequency Control (controlled by config, off by default). However when enable AFC works only on moment when squelch goes from ' ' to '*' by checking if some nearest freq has higher level. And moment when squelch goes back to ' ' - channel frequency reset back to config-defined value.
Added  -ffast-math option to GCC command line that allowed hardware FPU/NEON support. This subsequently allowed to get rid of asm-coded fftwave without performance degradation (actually it even a bit faster now). Unfortunatelly samplefft written in asm still bit faster than C code so it remain (but fixed to support different FFT sizes)