### PR TITLE
Add option to allow localtime vs UTC for output filenames

### DIFF
--- a/rtl_airband.conf.example
+++ b/rtl_airband.conf.example
@@ -67,6 +67,11 @@
 # Default value: 3 seconds
 # shout_metadata_delay = 3;
 
+# Use local timezone for output filenames
+# By default the time used for the output filenames will use UTC time.
+# Setting localtime to true will use the system's local timezone
+# localtime = false;
+
 # devices section contains all settings related to the RTLSDR receivers.
 #
 # It's a list of groups - each group contains settings for a single receiver,

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -256,6 +256,7 @@ int avx;
 #endif
 int foreground = 0, do_syslog = 1, shout_metadata_delay = 3;
 static volatile int do_exit = 0;
+bool use_localtime = false;
 #ifdef NFM
 float alpha = exp(-1.0f/(WAVE_RATE * 2e-4));
 enum fm_demod_algo {
@@ -637,7 +638,12 @@ void process_outputs(channel_t* channel, int cur_scan_freq) {
             file_data *fdata = (file_data *)(channel->outputs[k].data);
             if(fdata->continuous == false && channel->axcindicate == ' ' && channel->outputs[k].active == false) continue;
             time_t t = time(NULL);
-            struct tm *tmp = gmtime(&t);
+            struct tm *tmp;
+            if(use_localtime)
+                 tmp = localtime(&t);
+            else
+                 tmp = gmtime(&t);
+
             char suffix[32];
             if(strftime(suffix, sizeof(suffix), "_%Y%m%d_%H.mp3", tmp) == 0) {
                 log(LOG_NOTICE, "strftime returned 0\n");
@@ -1347,6 +1353,8 @@ int main(int argc, char* argv[]) {
             cerr<<"Configuration error: shout_metadata_delay is out of allowed range (0-"<<2 * TAG_QUEUE_LEN<<")\n";
             error();
         }
+        if(root.exists("localtime") && (bool)root["localtime"] == true)
+            use_localtime = true;
 #ifdef NFM
         if(root.exists("tau"))
             alpha = ((int)root["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)root["tau"])));


### PR DESCRIPTION
Updated pull on into unstable.

localtime is now a global config value