### PR TITLE
Add check for running as root (also, keep g++ happy)

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -327,7 +327,9 @@ void process_outputs(channel_t *channel, int cur_scan_freq) {
 // mp3_bytes is signed, but we've checked for negative values earlier
 // so it's save to ignore the warning here
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 			if(fwrite(lamebuf, 1, mp3_bytes, fdata->f) < mp3_bytes) {
+#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
 #pragma GCC diagnostic warning "-Wsign-compare"
 				if(ferror(fdata->f))
 					log(LOG_WARNING, "Cannot write to %s/%s%s (%s), output disabled\n",

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -672,6 +672,17 @@ int main(int argc, char* argv[]) {
 	}
 #endif /* !__arm__ */
 
+	// If executing other than as root, GPU memory gets alloc'd and the
+	// 'permission denied' message on /dev/mem kills rtl_airband without
+	// releasing GPU memory.
+#ifdef USE_BCM_VC
+	// XXX should probably do this check in other circumstances also.
+	if(0 != getuid()) {
+		cerr<<"FFT library requires that rtl_airband be executed as root\n";
+		exit(1);
+	}
+#endif
+
 	// read config
 	try {
 		Config config;


### PR DESCRIPTION
This is a subset of the PR to follow for your convenience in case you decide to accept these changes but don't want the squelch improvements I made (see #61).

This PR does two minor things, one of which is potentially quite important for pi users:
* Add check that executing as root when using the Broadcom GPU; if not root, `rtl_airband` dies (without deallocating FFT memory) because `hello_fft` can't map `/dev/mem`, and there appears to be no way to deallocate that memory except for rebooting.
* Add a pragma to suppress a spurious 'maybe-uninitialized' warning from g++.

Neither are critical, but the first one is a protection for newbies who don't realise that, unlike most RTL-SDR applications, this one must run as root and who, even when they try that, may already have exhausted GPU memory and require a reboot before they can successfully run `rtl_airband`.