### PR TITLE
Improve squelch handling in scan mode

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -211,8 +211,8 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 				for(int f = 0; f<channel->freq_count; f++) {
 					channel->freqlist[f].sqlevel = (int)chans[j]["squelch"][f];
 				}
-				// NB: no value check; -1 allows AGC for some frequencies and
-				//     not others.
+				// NB: no value check; -1 allows auto-squelch for
+				//     some frequencies and not others.
 			} else if(libconfig::Setting::TypeInt == chans[j]["squelch"].getType()) {
 				// Legacy (single squelch for all frequencies)
 				int sqlevel = (int)chans[j]["squelch"];

--- a/config/reference.conf
+++ b/config/reference.conf
@@ -127,11 +127,16 @@ devices = (
         disable = false;
 # Modulation - "am" or "nfm". Default is "am".
         modulation = "am";
-# Squelch level (integer, greater than 0). Default is auto.
+# Squelch level (integer greater than 0 or list of integers with length equal
+# to that of list freqs).  Default is auto.  When a list, squelch for each
+# frequency is set according to corresponding position.  A squelch of -1 sets
+# the corresponding frequency to automatic squelch.
 # Set this parameter only when auto squelch does not work correctly
 # (this is common with channels which transmit continuously, like ATIS/AWOS,
 # when auto squelch is unable to figure out the correct noise floor level)
 #        squelch = 100;
+# or
+#        squelch = ( 75, -1, 100, 87 );
 # Automatic Frequency Control (AFC) level (optional value)
 # 0 - disabled (by default)
 # value from range 1...10 - AFC enabled, larger value means more aggressive AFC.

--- a/output.cpp
+++ b/output.cpp
@@ -327,7 +327,9 @@ void process_outputs(channel_t *channel, int cur_scan_freq) {
 // mp3_bytes is signed, but we've checked for negative values earlier
 // so it's save to ignore the warning here
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 			if(fwrite(lamebuf, 1, mp3_bytes, fdata->f) < mp3_bytes) {
+#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
 #pragma GCC diagnostic warning "-Wsign-compare"
 				if(ferror(fdata->f))
 					log(LOG_WARNING, "Cannot write to %s/%s%s (%s), output disabled\n",

--- a/output.cpp
+++ b/output.cpp
@@ -241,7 +241,7 @@ static int fdata_open(file_data *fdata, const char *filename, mix_modes mixmode)
 
 unsigned char lamebuf[LAMEBUF_SIZE];
 void process_outputs(channel_t *channel, int cur_scan_freq) {
-	int mp3_bytes;
+	int mp3_bytes = 0;
 	if(channel->need_mp3) {
 		debug_bulk_print("channel->mode=%s\n", channel->mode == MM_STEREO ? "MM_STEREO" : "MM_MONO");
 		mp3_bytes = lame_encode_buffer_ieee_float(
@@ -327,9 +327,7 @@ void process_outputs(channel_t *channel, int cur_scan_freq) {
 // mp3_bytes is signed, but we've checked for negative values earlier
 // so it's save to ignore the warning here
 #pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 			if(fwrite(lamebuf, 1, mp3_bytes, fdata->f) < mp3_bytes) {
-#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
 #pragma GCC diagnostic warning "-Wsign-compare"
 				if(ferror(fdata->f))
 					log(LOG_WARNING, "Cannot write to %s/%s%s (%s), output disabled\n",

--- a/output.cpp
+++ b/output.cpp
@@ -277,10 +277,10 @@ void process_outputs(channel_t *channel, int cur_scan_freq) {
 			} else if(icecast->send_scan_freq_tags && cur_scan_freq >= 0) {
 				shout_metadata_t *meta = shout_metadata_new();
 				char description[32];
-				if(channel->labels[cur_scan_freq] != NULL)
-					shout_metadata_add(meta, "song", channel->labels[cur_scan_freq]);
+				if(channel->freqlist[channel->freq_idx].label != NULL)
+					shout_metadata_add(meta, "song", channel->freqlist[channel->freq_idx].label);
 				else {
-					snprintf(description, sizeof(description), "%.3f MHz", channel->freqlist[cur_scan_freq] / 1000000.0);
+					snprintf(description, sizeof(description), "%.3f MHz", channel->freqlist[channel->freq_idx].frequency / 1000000.0);
 					shout_metadata_add(meta, "song", description);
 				}
 				shout_set_metadata(icecast->shout, meta);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -672,6 +672,17 @@ int main(int argc, char* argv[]) {
 	}
 #endif /* !__arm__ */
 
+	// If executing other than as root, GPU memory gets alloc'd and the
+	// 'permission denied' message on /dev/mem kills rtl_airband without
+	// releasing GPU memory.
+#ifdef USE_BCM_VC
+	// XXX should probably do this check in other circumstances also.
+	if(0 != getuid()) {
+		cerr<<"FFT library requires that rtl_airband be executed as root\n";
+		exit(1);
+	}
+#endif
+
 	// read config
 	try {
 		Config config;

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -463,8 +463,9 @@ void demodulate() {
 			for (int i = 0; i < dev->channel_count; i++) {
 				AFC afc(dev, i);
 				channel_t* channel = dev->channels + i;
+				freq_t *fparms = channel->freqlist + channel->freq_idx;
 #if defined (__arm__) || defined (__aarch64__)
-				float agcmin2 = channel->freqlist[channel->freq_idx].agcmin * 4.5f;
+				float agcmin2 = fparms->agcmin * 4.5f;
 				for (int j = 0; j < WAVE_BATCH + AGC_EXTRA; j++) {
 					channel->waveref[j] = min(channel->wavein[j], agcmin2);
 				}
@@ -477,24 +478,24 @@ void demodulate() {
 #endif
 				for (int j = AGC_EXTRA; j < WAVE_BATCH + AGC_EXTRA; j++) {
 					// auto noise floor
-					if (channel->freqlist[channel->freq_idx].sqlevel < 0 && j % 16 == 0) {
-						channel->freqlist[channel->freq_idx].agcmin = channel->freqlist[channel->freq_idx].agcmin * 0.97f + min(channel->freqlist[channel->freq_idx].agcavgslow, channel->freqlist[channel->freq_idx].agcmin) * 0.03f + 0.0001f;
+					if (fparms->sqlevel < 0 && j % 16 == 0) {
+						fparms->agcmin = fparms->agcmin * 0.97f + min(fparms->agcavgslow, fparms->agcmin) * 0.03f + 0.0001f;
 					}
 
 					// average power
-					channel->freqlist[channel->freq_idx].agcavgslow = channel->freqlist[channel->freq_idx].agcavgslow * 0.99f + channel->waveref[j] * 0.01f;
+					fparms->agcavgslow = fparms->agcavgslow * 0.99f + channel->waveref[j] * 0.01f;
 
-					float sqlevel = channel->freqlist[channel->freq_idx].sqlevel > 0 ? (float)channel->freqlist[channel->freq_idx].sqlevel : 3.0f * channel->freqlist[channel->freq_idx].agcmin;
+					float sqlevel = fparms->sqlevel > 0 ? (float)fparms->sqlevel : 3.0f * fparms->agcmin;
 					if (channel->agcsq > 0) {
 						channel->agcsq = max(channel->agcsq - 1, 1);
-						if (channel->agcsq == 1 && channel->freqlist[channel->freq_idx].agcavgslow > sqlevel) {
+						if (channel->agcsq == 1 && fparms->agcavgslow > sqlevel) {
 							channel->agcsq = -AGC_EXTRA * 2;
 							channel->axcindicate = '*';
 							if(channel->modulation == MOD_AM) {
 							// fade in
 								for (int k = j - AGC_EXTRA; k < j; k++) {
 									if (channel->wavein[k] > sqlevel) {
-										channel->freqlist[channel->freq_idx].agcavgfast = channel->freqlist[channel->freq_idx].agcavgfast * 0.9f + channel->wavein[k] * 0.1f;
+										fparms->agcavgfast = fparms->agcavgfast * 0.9f + channel->wavein[k] * 0.1f;
 									}
 								}
 							}
@@ -502,13 +503,13 @@ void demodulate() {
 					} else {
 						if (channel->wavein[j] > sqlevel) {
 							if(channel->modulation == MOD_AM)
-								channel->freqlist[channel->freq_idx].agcavgfast = channel->freqlist[channel->freq_idx].agcavgfast * 0.995f + channel->wavein[j] * 0.005f;
-							channel->freqlist[channel->freq_idx].agclow = 0;
+								fparms->agcavgfast = fparms->agcavgfast * 0.995f + channel->wavein[j] * 0.005f;
+							fparms->agclow = 0;
 						} else {
-							channel->freqlist[channel->freq_idx].agclow++;
+							fparms->agclow++;
 						}
 						channel->agcsq = min(channel->agcsq + 1, -1);
-						if (channel->freqlist[channel->freq_idx].agclow == AGC_EXTRA - 12) {
+						if (fparms->agclow == AGC_EXTRA - 12) {
 							channel->agcsq = AGC_EXTRA * 2;
 							channel->axcindicate = ' ';
 							if(channel->modulation == MOD_AM) {
@@ -523,10 +524,10 @@ void demodulate() {
 						channel->waveout[j] = 0;
 					} else {
 						if(channel->modulation == MOD_AM) {
-							channel->waveout[j] = (channel->wavein[j - AGC_EXTRA] - channel->freqlist[channel->freq_idx].agcavgfast) / (channel->freqlist[channel->freq_idx].agcavgfast * 1.5f);
+							channel->waveout[j] = (channel->wavein[j - AGC_EXTRA] - fparms->agcavgfast) / (fparms->agcavgfast * 1.5f);
 							if (abs(channel->waveout[j]) > 0.8f) {
 								channel->waveout[j] *= 0.85f;
-								channel->freqlist[channel->freq_idx].agcavgfast *= 1.15f;
+								fparms->agcavgfast *= 1.15f;
 							}
 						}
 #ifdef NFM
@@ -545,8 +546,8 @@ void demodulate() {
 							channel->pr = rotated_r;
 							channel->pj = rotated_j;
 // de-emphasis IIR + DC blocking
-							channel->freqlist[channel->freq_idx].agcavgfast = channel->freqlist[channel->freq_idx].agcavgfast * 0.995f + channel->waveout[j] * 0.005f;
-							channel->waveout[j] -= channel->freqlist[channel->freq_idx].agcavgfast;
+							fparms->agcavgfast = fparms->agcavgfast * 0.995f + channel->waveout[j] * 0.005f;
+							channel->waveout[j] -= fparms->agcavgfast;
 							channel->waveout[j] = channel->waveout[j] * (1.0f - channel->alpha) + channel->waveout[j-1] * channel->alpha;
 						}
 #endif // NFM
@@ -570,9 +571,9 @@ void demodulate() {
 
 				if (foreground) {
 					if(dev->mode == R_SCAN)
-						printf("%4.0f/%3.0f%c %7.3f", channel->freqlist[channel->freq_idx].agcavgslow, channel->freqlist[channel->freq_idx].agcmin, channel->axcindicate, (dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
+						printf("%4.0f/%3.0f%c %7.3f", fparms->agcavgslow, fparms->agcmin, channel->axcindicate, (dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					else
-						printf("%4.0f/%3.0f%c", channel->freqlist[channel->freq_idx].agcavgslow, channel->freqlist[channel->freq_idx].agcmin, channel->axcindicate);
+						printf("%4.0f/%3.0f%c", fparms->agcavgslow, fparms->agcmin, channel->axcindicate);
 					fflush(stdout);
 				}
 			}

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -470,7 +470,7 @@ void demodulate() {
 					channel->waveref[j] = min(channel->wavein[j], agcmin2);
 				}
 #else
-				__m128 agccap = _mm_set1_ps(channel->agcmin * 4.5f);
+				__m128 agccap = _mm_set1_ps(fparms->agcmin * 4.5f);
 				for (int j = 0; j < WAVE_BATCH + AGC_EXTRA; j += 4) {
 					__m128 t = _mm_loadu_ps(channel->wavein + j);
 					_mm_storeu_ps(channel->waveref + j, _mm_min_ps(t, agccap));

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -132,6 +132,15 @@ enum modulations {
 
 enum ch_states { CH_DIRTY, CH_WORKING, CH_READY };
 enum mix_modes { MM_MONO, MM_STEREO };
+struct freq_t {
+	int frequency;				// scan frequency
+	char *label;				// frequency label
+	float agcavgfast;			// average power, for AGC
+	float agcavgslow;			// average power, for squelch level detection
+	float agcmin;				// noise level
+	int sqlevel;				// manually configured squelch level
+	int agclow;				// low level sample count
+};
 struct channel_t {
 	float wavein[WAVE_LEN];		// FFT output waveform
 	float waveref[WAVE_LEN];	// for power level calculation
@@ -150,17 +159,11 @@ struct channel_t {
 	enum modulations modulation;
 	enum mix_modes mode;		// mono or stereo
 	int agcsq;					// squelch status, 0 = signal, 1 = suppressed
-	float agcavgfast;			// average power, for AGC
-	float agcavgslow;			// average power, for squelch level detection
-	float agcmin;				// noise level
-	int sqlevel;				// manually configured squelch level
-	int agclow;					// low level sample count
 	char axcindicate;			// squelch/AFC status indicator: ' ' - no signal; '*' - has signal; '>', '<' - signal tuned by AFC
 	unsigned char afc;			//0 - AFC disabled; 1 - minimal AFC; 2 - more aggressive AFC and so on to 255
-	int frequency;
+	struct freq_t *freqlist;
 	int freq_count;
-	int *freqlist;
-	char **labels;
+	int freq_idx;
 	int output_count;
 	int need_mp3;
 	enum ch_states state;		// mixer channel state flag


### PR DESCRIPTION
This PR incorporates the changes in PR #62 and addresses the AGC and squelch issue raised in #61.  

It does two things:
* Enhances channel config kw `squelch` to accept a list of squelch values to be applied to corresponding frequencies in `freqs` (maintains backward compatibility with integer values of `squelch`), and
* keeps separate AGC parameters on a frequency-by-frequency basis.

The result is better auto-squelch performance (because signal levels, which may vary significantly depending on frequency, aren't being aggregated across all frequencies in the scan list) and when that's not enough, each frequency can be assigned a squelch value or left on automatic according to user's needs.

It also refactors the code a bit to keep frequency and label (if any) together with squelch and AGC parameters and cleans up the scanning hack a little.  The currently selected frequency and associated parameters is now available to all parts of the code as required.
