### PR TITLE
Add high and low pass filter parameters

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -207,6 +207,8 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 		channel->need_mp3 = 0;
 		channel->freq_count = 1;
 		channel->freq_idx = 0;
+		channel->highpass = chans[j].exists("highpass") ? (int)chans[j]["highpass"] : 100;
+		channel->lowpass = chans[j].exists("lowpass") ? (int)chans[j]["lowpass"] : 2500;
 		if(chans[j].exists("modulation")) {
 #ifdef NFM
 			if(!strncmp(chans[j]["modulation"], "nfm", 3)) {

--- a/output.cpp
+++ b/output.cpp
@@ -112,7 +112,7 @@ void shout_setup(icecast_data *icecast, mix_modes mixmode) {
 	}
 }
 
-lame_t airlame_init(mix_modes mixmode) {
+lame_t airlame_init(mix_modes mixmode, int highpass, int lowpass) {
 	lame_t lame = lame_init();
 	if (!lame) {
 		log(LOG_WARNING, "lame_init failed\n");
@@ -123,6 +123,8 @@ lame_t airlame_init(mix_modes mixmode) {
 	lame_set_VBR(lame, vbr_mtrh);
 	lame_set_brate(lame, 16);
 	lame_set_quality(lame, 7);
+	lame_set_lowpassfreq(lame, lowpass);
+	lame_set_highpassfreq(lame, highpass);
 	lame_set_out_samplerate(lame, MP3_RATE);
 	if(mixmode == MM_STEREO) {
 		lame_set_num_channels(lame, 2);
@@ -157,7 +159,7 @@ public:
 			}
 		} else
 			memset(buf, 0, samples * sizeof(float));
-		lame_t lame = airlame_init(mixmode);
+		lame_t lame = airlame_init(mixmode, 0, 0);
 		if (lame) {
 			_bytes = lame_encode_buffer_ieee_float(lame, buf, (mixmode == MM_STEREO ? buf : NULL), samples, _data, LAMEBUF_SIZE);
 			if (_bytes > 0) {

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -840,7 +840,7 @@ int main(int argc, char* argv[]) {
 			continue;		// no inputs connected = no need to initialize output
 		channel_t *channel = &mixers[i].channel;
 		if(channel->need_mp3)
-			channel->lame = airlame_init(mixers[i].channel.mode);
+			channel->lame = airlame_init(mixers[i].channel.mode, 0, 0);
 		for (int k = 0; k < channel->output_count; k++) {
 			output_t *output = channel->outputs + k;
 			if(output->type == O_ICECAST) {
@@ -859,7 +859,7 @@ int main(int argc, char* argv[]) {
 			channel_t* channel = dev->channels + j;
 
 			if(channel->need_mp3)
-				channel->lame = airlame_init(channel->mode);
+				channel->lame = airlame_init(channel->mode, channel->highpass, channel->lowpass);
 			for (int k = 0; k < channel->output_count; k++) {
 				output_t *output = channel->outputs + k;
 				if(output->type == O_ICECAST) {

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -204,6 +204,8 @@ struct channel_t {
 	int has_iq_outputs;
 	enum ch_states state;		// mixer channel state flag
 	output_t *outputs;
+	int highpass;               // highpass filter cutoff
+	int lowpass;                // lowpass filter cutoff
 	lame_t lame;
 };
 
@@ -249,7 +251,7 @@ struct mixer_t {
 };
 
 // output.cpp
-lame_t airlame_init(mix_modes mixmode);
+lame_t airlame_init(mix_modes mixmode, int highpass, int lowpass);
 void shout_setup(icecast_data *icecast, mix_modes mixmode);
 void disable_device_outputs(device_t *dev);
 void disable_channel_outputs(channel_t *channel);


### PR DESCRIPTION
This PR adds config parameters (in a channel spec) for high and low-pass filtering of the audio. The defaults are 100-2500Hz. This significantly improves the audio quality by suppressing high frequency noise. Setting the low or high pass values to 0 will replicate current behaviour (automatic selection by Lame) and -1 will disable the filter.

Example config:
````
  channels:
  (
    {
      freq = 118.1;
      lowpass = 2500;
      highpass = 150;
      outputs: (
        {
          type = "icecast";
````