### PR TITLE
log frequency when squelch opened in scan mode

### DIFF
--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -80,6 +80,7 @@ int do_syslog = 1;
 int shout_metadata_delay = 3;
 volatile int do_exit = 0;
 bool use_localtime = false;
+bool syslog_opened_squelch = false;
 size_t fft_size_log = DEFAULT_FFT_SIZE_LOG;
 size_t fft_size = 1 << fft_size_log;
 #ifdef NFM
@@ -125,6 +126,8 @@ void* controller_thread(void* params) {
 			}
 		} else {
 			if(consecutive_squelch_off == 10) {
+				if(syslog_opened_squelch)
+					log(LOG_INFO, "Squelch opened on %7.3f\n", dev->channels[0].freqlist[i].frequency / 1000000.0);
 				if(i != dev->last_frequency) {
 // squelch has just opened on a new frequency - we might need to update outputs' metadata
 					gettimeofday(&tv, NULL);
@@ -728,6 +731,8 @@ int main(int argc, char* argv[]) {
 		}
 		if(root.exists("localtime") && (bool)root["localtime"] == true)
 			use_localtime = true;
+		if(root.exists("syslog_opened_squelch") && (bool)root["syslog_opened_squelch"] == true)
+                        syslog_opened_squelch = true;
 #ifdef NFM
 		if(root.exists("tau"))
 			alpha = ((int)root["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)root["tau"])));


### PR DESCRIPTION
When the global variable `syslog_opened_squelch = true;`, writes an event to syslog with the frequency that the squelch opened on.

Figured I'd take a shot at my feature request - #113 - looking for a pull into unstable as it looks like that's where all the development happens.

Sample output from `/var/log/daemon.log`:
`Feb 24 11:48:05 scanner1 rtl_airband[2172]: Squelch opened on 133.475`
`Feb 24 11:48:14 scanner1 rtl_airband[2172]: Squelch opened on 133.475`
`Feb 24 11:48:17 scanner1 rtl_airband[2172]: Squelch opened on 127.550`
`Feb 24 11:48:30 scanner1 rtl_airband[2172]: Squelch opened on 133.100`
`Feb 24 11:48:39 scanner1 rtl_airband[2172]: Squelch opened on 126.500`
`Feb 24 11:48:52 scanner1 rtl_airband[2172]: Squelch opened on 126.500`
`Feb 24 11:49:03 scanner1 rtl_airband[2172]: Squelch opened on 127.550`
`Feb 24 11:49:10 scanner1 rtl_airband[2172]: Squelch opened on 127.550`
`Feb 24 11:49:19 scanner1 rtl_airband[2172]: Squelch opened on 127.550`
`Feb 24 11:49:32 scanner1 rtl_airband[2172]: Squelch opened on 127.550`
`Feb 24 11:49:36 scanner1 rtl_airband[2172]: Squelch opened on 133.100`
`Feb 24 11:49:45 scanner1 rtl_airband[2172]: Squelch opened on 127.550`

This is my first ever pull request - any feedback appreciated.