### PR TITLE
Fitipower FC0012 Fix Gain Setting

### DIFF
--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -118,20 +118,20 @@ int rtlsdr_init(input_t * const input) {
 		log(LOG_ERR, "Failed to set freq correction for device #%d. Error %d.\n", dev_data->index, r);
 	}
 
-	// Fitipower FC0012 gain seems to be relative to its last state so we need to initialize it to 0 in order to set it to our desired value
-	 if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
-	 	int initialGain = -10;
-	 	if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
-	 		log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
-	 		error();
-         	}
+	// Fitipower FC0012 gain needs to be initialized to its lowest value before setting it to the desired value
+	if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
+		int initialGain = -10;
+		if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
+			log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
+			error();
+        	}
 
-	 	r |= rtlsdr_set_tuner_gain(rtl, initialGain);
+		r |= rtlsdr_set_tuner_gain(rtl, initialGain);
 		if (r < 0) {
 	 		log(LOG_ERR, "Failed to initialize gain for device #%d: error %d\n",
 	 			(float)initialGain / 10.f, dev_data->index, r);
 	 	}
-	 }
+	}
 
 	int ngain = 0;
 	if(rtlsdr_nearest_gain(rtl, dev_data->gain, &ngain) != true) {

--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -119,19 +119,19 @@ int rtlsdr_init(input_t * const input) {
 	}
 
 	// Fitipower FC0012 gain seems to be relative to its last state so we need to initialize it to 0 in order to set it to our desired value
-	if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
-		int initialGain = 0;
-		if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
-			log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
-			error();
-        	}
+	 if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
+	 	int initialGain = -10;
+	 	if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
+	 		log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
+	 		error();
+         	}
 
-		r |= rtlsdr_set_tuner_gain(rtl, initialGain);
+	 	r |= rtlsdr_set_tuner_gain(rtl, initialGain);
 		if (r < 0) {
-			log(LOG_ERR, "Failed to initialize gain for device #%d: error %d\n",
-				(float)initialGain / 10.f, dev_data->index, r);
-		}
-	}
+	 		log(LOG_ERR, "Failed to initialize gain for device #%d: error %d\n",
+	 			(float)initialGain / 10.f, dev_data->index, r);
+	 	}
+	 }
 
 	int ngain = 0;
 	if(rtlsdr_nearest_gain(rtl, dev_data->gain, &ngain) != true) {

--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -118,13 +118,30 @@ int rtlsdr_init(input_t * const input) {
 		log(LOG_ERR, "Failed to set freq correction for device #%d. Error %d.\n", dev_data->index, r);
 	}
 
+	// Fitipower FC0012 gain seems to be relative to its last state so we need to initialize it to 0 in order to set it to our desired value
+	if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
+		int initialGain = 0;
+		if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
+			log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
+			error();
+        	}
+
+		r |= rtlsdr_set_tuner_gain(rtl, initialGain);
+		if (r < 0) {
+			log(LOG_ERR, "Failed to initialize gain for device #%d: error %d\n",
+				(float)initialGain / 10.f, dev_data->index, r);
+		}
+	}
+
 	int ngain = 0;
 	if(rtlsdr_nearest_gain(rtl, dev_data->gain, &ngain) != true) {
 		log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
 		error();
 	}
+	
 	r = rtlsdr_set_tuner_gain_mode(rtl, 1);
 	r |= rtlsdr_set_tuner_gain(rtl, ngain);
+
 	if (r < 0) {
 		log(LOG_ERR, "Failed to set gain to %0.2f for device #%d: error %d\n",
 			(float)ngain / 10.f, dev_data->index, r);

--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -120,8 +120,9 @@ int rtlsdr_init(input_t * const input) {
 
 	// Fitipower FC0012 gain needs to be initialized to its lowest value before setting it to the desired value
 	if (rtlsdr_get_tuner_type(rtl) == RTLSDR_TUNER_FC0012) {
-		int initialGain = -10;
-		if(rtlsdr_nearest_gain(rtl, 0, &initialGain) != true) {
+		int initialGain = 0;
+		int targetGain = -99;
+		if(rtlsdr_nearest_gain(rtl, targetGain, &initialGain) != true) {
 			log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
 			error();
         	}

--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -138,10 +138,8 @@ int rtlsdr_init(input_t * const input) {
 		log(LOG_ERR, "Failed to read supported gain list for device #%d\n", dev_data->index);
 		error();
 	}
-	
 	r = rtlsdr_set_tuner_gain_mode(rtl, 1);
 	r |= rtlsdr_set_tuner_gain(rtl, ngain);
-
 	if (r < 0) {
 		log(LOG_ERR, "Failed to set gain to %0.2f for device #%d: error %d\n",
 			(float)ngain / 10.f, dev_data->index, r);


### PR DESCRIPTION
The Fitipower FC0012 seems to have a problem with honoring the first gain setting when the device is first used. I found that the gain needs to first be set to the lowest value -9.9 and then set to the desired gain. I've reproduced this with GQRX and on different computers. I'm not sure if this is intentional for the FC0012, but it prevents gain on the device from being set correctly in this application. This PR is to add this workaround for the FC0012 so gain can be properly set.