### PR TITLE
Add notch filter to suppress CTCSS tones

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -278,6 +278,23 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 				error();
 			}
 		}
+		if(chans[j].exists("notch")) {
+			float freq = (float)chans[j]["notch"];
+			float gain = chans[j].exists("notch_gain") ? (float)chans[j]["notch_gain"] : 0.9;
+			float q = chans[j].exists("notch_q") ? (float)chans[j]["notch_q"] : 2.4;
+
+			if (gain <= 0.0 || gain >= 1.0) {
+				cerr << "Invalid value for notch_gain: " << gain << " (must be between 0.0 and 1.0 exclusive)\n";
+				error();
+			}
+
+			if (q <= 0.0) {
+				cerr << "Invalid value for notch_q: " << q << " (must be greater than 0.0)\n";
+				error();
+			}
+
+			channel->notch = NotchFilter(freq, WAVE_RATE, gain, q);
+		}
 #ifdef NFM
 		if(chans[j].exists("tau")) {
 			channel->alpha = ((int)chans[j]["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)chans[j]["tau"])));

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -1045,11 +1045,7 @@ void NotchFilter::apply(float &value) {
 	y[1] = y[2];
 	y[2] = d[0]*x[2] - d[1]*x[1] + d[0]*x[0] + d[1]*y[1] - d[2]*y[0];
 
-	if (skip_samples > 0) {
-		skip_samples--;
-	} else {
-		value = y[2];
-	}
+	value = y[2];
 }
 
 

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -177,7 +177,6 @@ public:
 
 private:
 	bool enabled;
-	int skip_samples;
 	float e;
 	float p;
 	float d[3];

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -168,6 +168,23 @@ enum modulations {
 #endif
 };
 
+class NotchFilter
+{
+public:
+	NotchFilter(void);
+	NotchFilter(float notch_freq, float sample_freq, float gain, float q);
+	void apply(float &value);
+
+private:
+	bool enabled;
+	int skip_samples;
+	float e;
+	float p;
+	float d[3];
+	float x[3];
+	float y[3];
+};
+
 struct freq_t {
 	int frequency;				// scan frequency
 	char *label;				// frequency label
@@ -207,6 +224,7 @@ struct channel_t {
 	int highpass;               // highpass filter cutoff
 	int lowpass;                // lowpass filter cutoff
 	lame_t lame;
+	NotchFilter notch;			// notch filter - good to remove CTCSS tones
 };
 
 enum rec_modes { R_MULTICHANNEL, R_SCAN };


### PR DESCRIPTION
Almost all of my NFM channels use CTCSS tones and the highpass filter didn't do enough to get rid of the hum.  Many of the tones are up at 150Hz - 200Hz and setting the lowpass filtering that high distorts the audio too much.

This adds a simple notch filter class based on the algorithm here: https://www.dsprelated.com/showcode/173.php

Here is an example of configuring with `notch_q` and `notch_gain` being optional.  Let me know if you want the name / structure to change:
```
        freq = 155.02500;
        modulation = "nfm";
        notch = 173.8;
        notch_q = 2.4;
        notch_gain = 0.9;
```