### PR TITLE
Support splitting file by transmission

### DIFF
--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -113,11 +113,14 @@ struct icecast_data {
 };
 
 struct file_data {
-	const char *dir;
-	const char *prefix;
+	char *basename;
 	char *suffix;
+	char *file_path;
 	bool continuous;
 	bool append;
+	bool split_on_transmission;
+	timeval open_time;
+	timeval last_write_time;
 	FILE *f;
 };
 


### PR DESCRIPTION
create new config options for 'file' and 'rawfile':
 - include_freq: add the frequency in Hz to the end of the filename
 - split_on_transmission: create a file per "transmission" rather than one per hour

Rework struct file_data and file open/close logic to support split_on_transmission