### PR TITLE
Add support to log per-channel “activity counts” to a stats file

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -213,6 +213,7 @@ static struct freq_t *mk_freqlist( int n )
 		fl[i].agcmin = 100.0f;
 		fl[i].agclow = 0;
 		fl[i].sqlevel = -1;
+		fl[i].active_counter = 0;
 	}
 	return fl;
 }
@@ -255,7 +256,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			channel->waveout[k] = 0.5;
 		}
 		channel->agcsq = 1;
-		channel->axcindicate = ' ';
+		channel->axcindicate = NO_SIGNAL;
 		channel->modulation = MOD_AM;
 		channel->mode = MM_MONO;
 		channel->need_mp3 = 0;
@@ -282,6 +283,10 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			channel->freqlist = mk_freqlist( 1 );
 			channel->freqlist[0].frequency = parse_anynum2int(chans[j]["freq"]);
 			warn_if_freq_not_in_range(i, j, channel->freqlist[0].frequency, dev->input->centerfreq, dev->input->sample_rate);
+			if (chans[j].exists("label"))
+			{
+				channel->freqlist[0].label = strdup(chans[j]["label"]);
+			}
 		} else { /* R_SCAN */
 			channel->freq_count = chans[j]["freqs"].getLength();
 			if(channel->freq_count < 1) {

--- a/config.cpp
+++ b/config.cpp
@@ -493,6 +493,7 @@ int parse_devices(libconfig::Setting &devs) {
 		dev->input->buffer = (unsigned char *)XCALLOC(sizeof(unsigned char),
 			dev->input->buf_size + 2 * dev->input->bytes_per_sample * fft_size);
 		dev->input->bufs = dev->input->bufe = 0;
+		dev->input->overflow_count = 0;
 		dev->waveend = dev->waveavail = dev->row = dev->tq_head = dev->tq_tail = 0;
 		dev->last_frequency = -1;
 

--- a/input-common.h
+++ b/input-common.h
@@ -53,6 +53,7 @@ struct input_t {
 	unsigned char *buffer;
 	void *dev_data;
 	size_t buf_size, bufs, bufe;
+	size_t overflow_count;
 	input_state_t state;
 	sample_format_t sfmt;
 	float fullscale;

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -163,17 +163,17 @@ void *mixer_thread(void *) {
 						memset(channel->waveout, 0, WAVE_BATCH * sizeof(float));
 						if(channel->mode == MM_STEREO)
 							memset(channel->waveout_r, 0, WAVE_BATCH * sizeof(float));
-						channel->axcindicate = ' ';
+						channel->axcindicate = NO_SIGNAL;
 						channel->state = CH_WORKING;
 					}
 					debug_bulk_print("mixer[%d]: ampleft=%.1f ampright=%.1f\n", i, input->ampfactor * input->ampl, input->ampfactor * input->ampr);
 					/* left channel */
 					if(mix_waveforms(channel->waveout, input->wavein, input->ampfactor * input->ampl, WAVE_BATCH))
-						channel->axcindicate = '*';
+						channel->axcindicate = SIGNAL;
 					/* right channel */
 					if(channel->mode == MM_STEREO) {
 						if(mix_waveforms(channel->waveout_r, input->wavein, input->ampfactor * input->ampr, WAVE_BATCH))
-							channel->axcindicate = '*';
+							channel->axcindicate = SIGNAL;
 					}
 					input->ready = false;
 					RESET_BIT(mixer->inputs_todo, j);

--- a/output.cpp
+++ b/output.cpp
@@ -18,9 +18,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -496,40 +494,42 @@ void write_stats_file(timeval *last_stats_write) {
 
 	*last_stats_write = current_time;
 
-	std::ofstream file;
-	file.open(stats_filepath);
-	if (!file.is_open()) {
+	FILE *file = fopen(stats_filepath, "w");
+	if (!file) {
 		log(LOG_WARNING, "Cannot open output file %s (%s)\n", stats_filepath, strerror(errno));
 		return;
 	}
-	std::stringstream activity, noise, overflow;
 
-	activity << "# HELP channel_activity_counter Loops of output_thread with frequency active.\n"
-			 << "# TYPE channel_activity_counter counter\n";
-	noise << "# HELP channel_noise_level Measure of agcmin.\n"
-		  << "# TYPE channel_noise_level gauge\n";
-	overflow << "# HELP buffer_overflow_count Number of times a device's buffer has overflowed.\n"
-			 << "# TYPE buffer_overflow_count counter\n";
+	char noise[2048];
+	char overflow[256];
+	size_t noise_len = 0;
+	size_t overflow_len = 0;
+
+	fprintf(file, "# HELP channel_activity_counter Loops of output_thread with frequency active.\n"
+				  "# TYPE channel_activity_counter counter\n");
 
 	for (int i = 0; i < device_count; i++) {
 		device_t* dev = devices + i;
-		overflow << "buffer_overflow_count{device=\"" << i << "\"}\t" << dev->input->overflow_count << std::endl;
 		for (int j = 0; j < dev->channel_count; j++) {
 			channel_t* channel = devices[i].channels + j;
 			for (int k = 0; k < channel->freq_count; k++) {
-				std::stringstream labels;
-				labels << "{freq=\"" << channel->freqlist[k].frequency / 1000000.0 ;
+				char tmp[256];
+				size_t len = snprintf(tmp, sizeof(tmp), "freq=\"%.3f\"", channel->freqlist[k].frequency / 1000000.0);
 				if (channel->freqlist[k].label) {
-					labels << "\",label=\"" << channel->freqlist[k].label << "\"}\t";
+					len += snprintf(tmp + len, sizeof(tmp) - len, ",label=\"%s\"", channel->freqlist[k].label);
 				}
-				activity << "channel_activity_counter" << labels.str() << channel->freqlist[k].active_counter << std::endl;
-				noise << "channel_noise_level" << labels.str() << channel->freqlist[k].agcmin << std::endl;
+				fprintf(file, "channel_activity_counter{%s}\t%zu\n", tmp, channel->freqlist[k].active_counter);
+				noise_len += snprintf(noise + noise_len, sizeof(noise) - noise_len, "channel_noise_level{%s}\t%.3f\n", tmp, channel->freqlist[k].agcmin);
 			}
 		}
+		overflow_len += snprintf(overflow, sizeof(overflow) - overflow_len, "buffer_overflow_count{device=\"%d\"}\t%zu\n", i , dev->input->overflow_count);
 	}
 
-	file << activity.str() << std::endl << noise.str() << std::endl << overflow.str();
-	file.close();
+	fprintf(file, "\n# HELP channel_noise_level Measure of agcmin.\n"
+				  "# TYPE channel_noise_level gauge\n%s", noise);
+	fprintf(file, "\n# HELP buffer_overflow_count Number of times a device's buffer has overflowed.\n"
+				  "# TYPE buffer_overflow_count counter.\n%s", overflow);
+	fclose(file);
 }
 
 void* output_thread(void*) {

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -97,6 +97,7 @@ extern "C" void samplefft(sample_fft_arg *a, unsigned char* buffer, float* windo
 
 //#define AFC_LOGGING
 
+enum status {NO_SIGNAL = ' ', SIGNAL = '*', AFC_UP = '<', AFC_DOWN = '>' };
 enum ch_states { CH_DIRTY, CH_WORKING, CH_READY };
 enum mix_modes { MM_MONO, MM_STEREO };
 struct icecast_data {
@@ -194,7 +195,8 @@ struct freq_t {
 	float agcavgslow;			// average power, for squelch level detection
 	float agcmin;				// noise level
 	int sqlevel;				// manually configured squelch level
-	int agclow;				// low level sample count
+	int agclow;					// low level sample count
+	size_t active_counter;		// count of loops where channel has signal
 };
 struct channel_t {
 	float wavein[WAVE_LEN];		// FFT output waveform
@@ -212,7 +214,7 @@ struct channel_t {
 	enum modulations modulation;
 	enum mix_modes mode;		// mono or stereo
 	int agcsq;					// squelch status, 0 = signal, 1 = suppressed
-	char axcindicate;			// squelch/AFC status indicator: ' ' - no signal; '*' - has signal; '>', '<' - signal tuned by AFC
+	status axcindicate;
 	unsigned char afc;			//0 - AFC disabled; 1 - minimal AFC; 2 - more aggressive AFC and so on to 255
 	struct freq_t *freqlist;
 	int freq_count;
@@ -280,6 +282,7 @@ void *output_thread(void* params);
 
 // rtl_airband.cpp
 extern bool use_localtime;
+extern char *stats_filepath;
 extern size_t fft_size, fft_size_log;
 extern int device_count, mixer_count;
 extern int shout_metadata_delay, do_syslog, foreground;


### PR DESCRIPTION
Add support to log per-channel “activity counts” to a stats file.  File is formatted to be ingested by Prometheus (https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md).  Counter value is number of loops of output_thread with frequency active.

Also:
 - changed axcindicate to an enum instead of hard-coded characters
 - add ‘label’ config parameter for single channel (similar to ‘labels’ for scan mode)