### PR TITLE
Add bandwidth filter

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -210,6 +210,7 @@ static struct freq_t *mk_freqlist( int n )
 		fl[i].label = NULL;
 		fl[i].agcavgfast = 0.5f;
 		fl[i].agcavgslow = 0.5f;
+		fl[i].filter_avg = 0.5f;
 		fl[i].agcmin = 100.0f;
 		fl[i].agclow = 0;
 		fl[i].sqlevel = -1;
@@ -310,7 +311,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 				error();
 			}
 			if(chans[j].exists("notch_q") && libconfig::Setting::TypeList == chans[j]["notch_q"].getType() && chans[j]["notch_q"].getLength() < channel->freq_count) {
-				cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"]: notch_q should be an float or a list of floats with at least "
+				cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"]: notch_q should be a float or a list of floats with at least "
 					<<channel->freq_count<<" elements\n";
 				error();
 			}
@@ -364,7 +365,11 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 							<<q<<" (must be greater than 0.0)\n";
 						error();
 					}
-					channel->freqlist[f].notch_filter = NotchFilter(freq, WAVE_RATE, q);
+					if(freq <= 0) {
+						cerr << "devices.["<<i<<"] channels.["<<j<<"] freq.["<<f<<"]: invalid value for notch: "<<freq<<", ignoring\n";
+					} else {
+						channel->freqlist[f].notch_filter = NotchFilter(freq, WAVE_RATE, q);
+					}
 				}
 			} else if(libconfig::Setting::TypeFloat == chans[j]["notch"].getType() ) {
 				float freq = (float)chans[j]["notch"];
@@ -375,7 +380,11 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 					error();
 				}
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].notch_filter = NotchFilter(freq, WAVE_RATE, q);;
+					if(freq <= 0) {
+						cerr << "devices.["<<i<<"] channels.["<<j<<"]: freq value '"<<freq<<"' invalid, ignoring\n";
+					} else {
+						channel->freqlist[f].notch_filter = NotchFilter(freq, WAVE_RATE, q);
+					}
 				}
 			} else {
 				cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"]: notch should be an float or a list of floats with at least "
@@ -383,6 +392,35 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 				error();
 			}
 		}
+		if(chans[j].exists("bandwidth")) {
+			if(channel->modulation == MOD_AM) {
+				cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"]: bandwidth not supported for AM\n";
+				error();
+			}
+
+			channel->needs_raw_iq = 1;
+
+			if(libconfig::Setting::TypeList == chans[j]["bandwidth"].getType()) {
+				for(int f = 0; f<channel->freq_count; f++) {
+					int bandwidth = parse_anynum2int(chans[j]["bandwidth"][f]);
+					if(bandwidth <= 0) {
+						cerr << "devices.["<<i<<"] channels.["<<j<<"] freq.["<<f<<"]: bandwidth value '"<<bandwidth<<"' invalid, ignoring\n";
+					} else {
+						channel->freqlist[f].lowpass_filter = LowpassFilter((float)bandwidth/2, WAVE_RATE);
+					}
+				}
+			} else {
+				int bandwidth = parse_anynum2int(chans[j]["bandwidth"]);
+				if(bandwidth <= 0) {
+					cerr << "devices.["<<i<<"] channels.["<<j<<"]: bandwidth value '"<<bandwidth<<"' invalid, ignoring\n";
+				} else {
+					for(int f = 0; f<channel->freq_count; f++) {
+						channel->freqlist[f].lowpass_filter = LowpassFilter((float)bandwidth/2, WAVE_RATE);
+					}
+				}
+			}
+		}
+
 #ifdef NFM
 		if(chans[j].exists("tau")) {
 			channel->alpha = ((int)chans[j]["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)chans[j]["tau"])));

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -571,14 +571,15 @@ void *demodulate(void *params) {
 						channel->dm_phi += channel->dm_dphi;
 						channel->dm_phi &= 0xffffff;
 
+						// apply lowpass filter, will be a no-op if not configured
+						fparms->lowpass_filter.apply(re, im);
+
+						// update I/Q and wave
+						channel->iq_in[2*(j - AGC_EXTRA)] = re;
+						channel->iq_in[2*(j - AGC_EXTRA)+1] = im;
+						channel->wavein[j] = sqrt(re * re + im * im);
+
 						if(fparms->lowpass_filter.enabled()) {
-							fparms->lowpass_filter.apply(re, im);
-
-							// update I/Q and wave
-							channel->iq_in[2*(j - AGC_EXTRA)] = re;
-							channel->iq_in[2*(j - AGC_EXTRA)+1] = im;
-							channel->wavein[j] = sqrt(re * re + im * im);
-
 							fparms->filter_avg = fparms->filter_avg * 0.999f + channel->wavein[j] * 0.001f;
 
 							if (fparms->filter_avg < sqlevel) {

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -74,11 +74,7 @@
 #define MAX_MIXINPUTS 32
 
 #define MIN_FFT_SIZE_LOG 8
-#ifdef NFM
-#define DEFAULT_FFT_SIZE_LOG 10
-#else
 #define DEFAULT_FFT_SIZE_LOG 9
-#endif
 #define MAX_FFT_SIZE_LOG 13
 
 #define LAMEBUF_SIZE 22000 //todo: calculate

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -21,6 +21,7 @@
 #ifndef _RTL_AIRBAND_H
 #define _RTL_AIRBAND_H 1
 #include <cstdio>
+#include <complex>
 #include <stdint.h>		// uint32_t
 #include <pthread.h>
 #include <sys/time.h>
@@ -73,7 +74,11 @@
 #define MAX_MIXINPUTS 32
 
 #define MIN_FFT_SIZE_LOG 8
+#ifdef NFM
+#define DEFAULT_FFT_SIZE_LOG 10
+#else
 #define DEFAULT_FFT_SIZE_LOG 9
+#endif
 #define MAX_FFT_SIZE_LOG 13
 
 #define LAMEBUF_SIZE 22000 //todo: calculate
@@ -182,7 +187,7 @@ public:
 	void apply(float &value);
 
 private:
-	bool enabled;
+	bool enabled_;
 	float e;
 	float p;
 	float d[3];
@@ -190,16 +195,41 @@ private:
 	float y[3];
 };
 
+class LowpassFilter
+{
+public:
+	LowpassFilter(void);
+	LowpassFilter(float freq, float sample_freq);
+	void apply(float &r, float &j);
+	bool enabled(void) const {return enabled_;}
+
+private:
+	static std::complex<double> blt(std::complex<double> pz);
+	static void expand(std::complex<double> pz[], int npz, std::complex<double> coeffs[]);
+	static void multin(std::complex<double> w, int npz, std::complex<double> coeffs[]);
+	static std::complex<double> evaluate(std::complex<double> topco[], int nz, std::complex<double> botco[], int np, std::complex<double> z);
+	static std::complex<double> eval(std::complex<double> coeffs[], int npz, std::complex<double> z);
+
+	bool enabled_;
+	float ycoeffs[3];
+	float gain;
+
+	std::complex<float> xv[3];
+	std::complex<float> yv[3];
+};
+
 struct freq_t {
 	int frequency;				// scan frequency
 	char *label;				// frequency label
 	float agcavgfast;			// average power, for AGC
 	float agcavgslow;			// average power, for squelch level detection
+	float filter_avg;			// average power, for post-filter squelch level detection
 	float agcmin;				// noise level
 	int sqlevel;				// manually configured squelch level
 	int agclow;					// low level sample count
 	size_t active_counter;		// count of loops where channel has signal
 	NotchFilter notch_filter;	// notch filter - good to remove CTCSS tones
+	LowpassFilter lowpass_filter;	// lowpass filter, applied to I/Q after derotation, set at bandwidth/2 to remove out of band noise
 };
 struct channel_t {
 	float wavein[WAVE_LEN];		// FFT output waveform
@@ -216,7 +246,7 @@ struct channel_t {
 	uint32_t dm_dphi, dm_phi;	// derotation frequency and current phase value
 	enum modulations modulation;
 	enum mix_modes mode;		// mono or stereo
-	int agcsq;					// squelch status, 0 = signal, 1 = suppressed
+	int agcsq;					// squelch status, negative: signal, positive: suppressed
 	status axcindicate;
 	unsigned char afc;			//0 - AFC disabled; 1 - minimal AFC; 2 - more aggressive AFC and so on to 255
 	struct freq_t *freqlist;


### PR DESCRIPTION
Added a configurable bandwidth filter for NFM signals.  Can be set either for single channel or scan mode.

Filter is implemented as a low-pass after de-rotating then checking the average power vs squelch.

The calculation of the filter coefficients is based entirely on a simplification of what is posted here: https://www-users.cs.york.ac.uk/~fisher/mkfilter/

NOTE: Also change the default FFT size to 1024 when NFM is enabled.