### PR TITLE
Add Profiling

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,6 +91,11 @@ ifeq ($(WITH_SOAPYSDR), 1)
   LDLIBS += -lSoapySDR
 endif
 
+ifeq ($(WITH_PROFILING), 1)
+  CFLAGS += -DWITH_PROFILING
+  LDLIBS += -lprofiler
+endif
+
 ifeq ($(UNKNOWN_PLATFORM),1)
   DEPS =
 endif


### PR DESCRIPTION
Added a `WITH_PROFILING` option to the makefile that enables and links in Gperftools (can be installed with `apt-get install google-perftools libgoogle-perftools-dev`)

Profiling on a rpi3 using a ~100Mb test file showed large amounts of time spent in loading the FFT array:

```
Total: 3238 samples
     573  17.7%  17.7%      573  17.7% fftwf_codelet_t2fv_8_neon ??:0
     386  11.9%  29.6%      386  11.9% demodulate RTLSDR-Airband/rtl_airband.cpp:456
     377  11.6%  41.3%      377  11.6% demodulate RTLSDR-Airband/rtl_airband.cpp:457
     324  10.0%  51.3%      324  10.0% fftwf_codelet_n2fv_32_neon ??:0
     176   5.4%  56.7%      176   5.4% demodulate RTLSDR-Airband/rtl_airband.cpp:455
     154   4.8%  61.5%      154   4.8% demodulate RTLSDR-Airband/rtl_airband.cpp:454
     116   3.6%  65.0%      116   3.6% fftwf_cpy2d ??:0
     103   3.2%  68.2%      103   3.2% fftwf_cpy2d_pair ??:0
      80   2.5%  70.7%       80   2.5% fftwf_codelet_n1fv_15_neon ??:0
      65   2.0%  72.7%       65   2.0% fftwf_codelet_n1fv_16_neon ??:0
      64   2.0%  74.7%       64   2.0% fftwf_codelet_n1_7 ??:0
...
```

After playing around with the for loop, removing the variable based calculation of `buf2` in the loop as well as splitting the calculation of the real / imaginary values from storing into the FFT structure showed a significant improvement (better function unrolling?):

```
Total: 2565 samples
     512  20.0%  20.0%      512  20.0% fftwf_codelet_n2fv_32_neon ??:0
     453  17.7%  37.6%      453  17.7% fftwf_codelet_t1fv_15_neon ??:0
     162   6.3%  43.9%      162   6.3% demodulate RTLSDR-Airband/rtl_airband.cpp:456
     143   5.6%  49.5%      143   5.6% demodulate RTLSDR-Airband/rtl_airband.cpp:457
     113   4.4%  53.9%      113   4.4% fftwf_cpy2d ??:0
     107   4.2%  58.1%      107   4.2% fftwf_cpy2d_pair ??:0
      78   3.0%  61.1%       78   3.0% fftwf_codelet_n1fv_15_neon ??:0
      62   2.4%  63.5%       62   2.4% fftwf_codelet_n1_7 ??:0
      62   2.4%  66.0%       62   2.4% fftwf_codelet_n1fv_16_neon ??:0
      53   2.1%  68.0%       53   2.1% fftwf_ct_genericbuf_register ??:0
      48   1.9%  69.9%       48   1.9% fftwf_codelet_n1_15 ??:0
      46   1.8%  71.7%       46   1.8% demodulate RTLSDR-Airband/rtl_airband.cpp:459
      35   1.4%  73.1%       35   1.4% fftwf_dft_solve ??:0
      34   1.3%  74.4%       34   1.3% fftwf_codelet_n1fv_32_neon ??:0
      33   1.3%  75.7%       33   1.3% demodulate RTLSDR-Airband/rtl_airband.cpp:458
...
```

When deployed to a rpi4 with 3 SDRs there was ~5% drop in CPU load:

<img width="821" alt="Screen Shot 2020-09-16 at 1 30 40 PM" src="https://user-images.githubusercontent.com/13514783/93389322-dd14ef00-f820-11ea-9d3d-334690a86061.png">


The same change could be applied to the other architectures and sample sizes but I don't have setups to test.