### PR TITLE
Close RTLSDR device upon exit

### DIFF
--- a/input-rtlsdr.cpp
+++ b/input-rtlsdr.cpp
@@ -177,7 +177,7 @@ int rtlsdr_stop(input_t * const input) {
 	if(rtlsdr_cancel_async(dev_data->dev) < 0) {
 		return -1;
 	}
-	return 0;
+	return rtlsdr_close(dev_data->dev);
 }
 
 int rtlsdr_set_centerfreq(input_t * const input, int const centerfreq) {

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -1075,6 +1075,8 @@ int main(int argc, char* argv[]) {
 
 	log(LOG_INFO, "Cleaning up\n");
 	for (int i = 0; i < device_count; i++) {
+		if(devices[i].mode == R_SCAN)
+			pthread_join(devices[i].controller_thread, NULL);
 		if(input_stop(devices[i].input) != 0 || devices[i].input->state != INPUT_STOPPED) {
 			if(errno != 0) {
 				log(LOG_ERR, "Failed do stop device #%d: %s\n", i, strerror(errno));
@@ -1082,8 +1084,6 @@ int main(int argc, char* argv[]) {
 				log(LOG_ERR, "Failed do stop device #%d\n", i);
 			}
 		}
-		if(devices[i].mode == R_SCAN)
-			pthread_join(devices[i].controller_thread, NULL);
 	}
 	log(LOG_INFO, "Input threads closed\n");
 	close_debug();


### PR DESCRIPTION
Make sure that controller thread returns first so that it does not
attempt to set center frequency on a closed device.
After that, call rtlsdr_close from rtlsdr_stop.  Reference rtl_test
for an example of closing the device.