### PR TITLE
Logging for output thread and mixer thread overruns

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -564,6 +564,7 @@ int parse_devices(libconfig::Setting &devs) {
 			dev->input->buf_size + 2 * dev->input->bytes_per_sample * fft_size);
 		dev->input->bufs = dev->input->bufe = 0;
 		dev->input->overflow_count = 0;
+		dev->output_overrun_count = 0;
 		dev->waveend = dev->waveavail = dev->row = dev->tq_head = dev->tq_tail = 0;
 		dev->last_frequency = -1;
 
@@ -608,6 +609,7 @@ int parse_mixers(libconfig::Setting &mx) {
 		mixer->enabled = false;
 		mixer->name = strdup(name);
 		mixer->interval = MIX_DIVISOR;
+		mixer->output_overrun_count = 0;
 		channel_t *channel = &mixer->channel;
 		channel->highpass = mx[i].exists("highpass") ? (int)mx[i]["highpass"] : 100;
 		channel->lowpass = mx[i].exists("lowpass") ? (int)mx[i]["lowpass"] : 2500;

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -281,6 +281,7 @@ struct device_t {
 	int row;
 	int failed;
 	enum rec_modes mode;
+	size_t output_overrun_count;
 };
 
 struct mixinput_t {
@@ -289,6 +290,7 @@ struct mixinput_t {
 	float ampl, ampr;
 	bool ready;
 	pthread_mutex_t mutex;
+	size_t input_overrun_count;
 };
 
 struct mixer_t {
@@ -300,6 +302,7 @@ struct mixer_t {
 	unsigned int input_mask;
 	channel_t channel;
 	mixinput_t inputs[MAX_MIXINPUTS];
+	size_t output_overrun_count;
 };
 
 struct demod_params_t {


### PR DESCRIPTION
- add logging and stats for output thread overruns and mixer input/output overruns
- wait for mixer and output threads on shutdown
- write final stats file on shutdown
