### PR TITLE
Add flag to split output into multiple threads

### DIFF
--- a/mixer.cpp
+++ b/mixer.cpp
@@ -196,7 +196,7 @@ void *mixer_thread(void *) {
 	        	    ts.tv_usec = te.tv_usec;
 			    }
 				channel->state = CH_READY;
-				safe_cond_signal(&mixer_mp3_cond, &mixer_mp3_mutex);
+				mixer_mp3_signal.send();
 				mixer->interval = MIX_DIVISOR;
 				mixer->inputs_todo = ONES(mixer->input_count);
 			} else {

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -141,11 +141,11 @@ static bool mix_waveforms(float *sum, float *in, float mult, int size) {
 void *mixer_thread(void *param) {
 	assert(param != NULL);
 	Signal *signal = (Signal *)param;
+	struct timeval ts, te;
+	int interval_usec = 1e+6 * WAVE_BATCH / WAVE_RATE / MIX_DIVISOR;
 
 	debug_print("Starting mixer thread, signal %p\n", signal);
 
-	struct timeval ts, te;
-	int interval_usec = 1e+6 * WAVE_BATCH / WAVE_RATE / MIX_DIVISOR;
 	if(mixer_count <= 0) return 0;
 	if(DEBUG) gettimeofday(&ts, NULL);
 	while(!do_exit) {

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -138,7 +138,12 @@ static bool mix_waveforms(float *sum, float *in, float mult, int size) {
  *       interval. Any input which is still not ready, is skipped (filled with 0s), because
  *       here we must emit the mixed audio to keep the desired audio bitrate.
  */
-void *mixer_thread(void *) {
+void *mixer_thread(void *param) {
+	assert(param != NULL);
+	Signal *signal = (Signal *)param;
+
+	debug_print("Starting mixer thread, signal %p\n", signal);
+
 	struct timeval ts, te;
 	int interval_usec = 1e+6 * WAVE_BATCH / WAVE_RATE / MIX_DIVISOR;
 	if(mixer_count <= 0) return 0;
@@ -196,7 +201,7 @@ void *mixer_thread(void *) {
 	        	    ts.tv_usec = te.tv_usec;
 			    }
 				channel->state = CH_READY;
-				mixer_mp3_signal.send();
+				signal->send();
 				mixer->interval = MIX_DIVISOR;
 				mixer->inputs_todo = ONES(mixer->input_count);
 			} else {

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -196,7 +196,7 @@ void *mixer_thread(void *) {
 	        	    ts.tv_usec = te.tv_usec;
 			    }
 				channel->state = CH_READY;
-				safe_cond_signal(&mp3_cond, &mp3_mutex);
+				safe_cond_signal(&mixer_mp3_cond, &mixer_mp3_mutex);
 				mixer->interval = MIX_DIVISOR;
 				mixer->inputs_todo = ONES(mixer->input_count);
 			} else {

--- a/output.cpp
+++ b/output.cpp
@@ -42,6 +42,7 @@
 #include <cstring>
 #include <ctime>
 #include <cerrno>
+#include <cassert>
 #include "rtl_airband.h"
 #include "input-common.h"
 

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -293,7 +293,6 @@ struct device_t {
 // FIXME: size_t
 	int waveend;
 	int waveavail;
-	Signal mp3_signal;
 	THREAD controller_thread;
 	struct freq_tag tag_queue[TAG_QUEUE_LEN];
 	int tq_head, tq_tail;
@@ -327,8 +326,9 @@ struct mixer_t {
 };
 
 struct demod_params_t {
-	int start_device;
-	int end_device;
+	Signal *mp3_signal;
+	int device_start;
+	int device_end;
 
 #ifndef USE_BCM_VC
 	fftwf_plan fft;
@@ -337,18 +337,26 @@ struct demod_params_t {
 #endif
 };
 
+struct output_params_t {
+	Signal *mp3_signal;
+	int device_start;
+	int device_end;
+	int mixer_start;
+	int mixer_end;
+};
+
 // output.cpp
 lame_t airlame_init(mix_modes mixmode, int highpass, int lowpass);
 void shout_setup(icecast_data *icecast, mix_modes mixmode);
 void disable_device_outputs(device_t *dev);
 void disable_channel_outputs(channel_t *channel);
 void *output_check_thread(void* params);
-void *device_output_thread(void* params);
-void *mixer_output_thread(void* params);
+void *output_thread(void* params);
 
 // rtl_airband.cpp
 extern bool use_localtime;
 extern bool multiple_demod_threads;
+extern bool multiple_output_threads;
 extern char *stats_filepath;
 extern size_t fft_size, fft_size_log;
 extern int device_count, mixer_count;
@@ -357,7 +365,6 @@ extern volatile int do_exit, device_opened;
 extern float alpha;
 extern device_t *devices;
 extern mixer_t *mixers;
-extern Signal mixer_mp3_signal;
 
 // util.cpp
 void error();

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -323,7 +323,8 @@ void shout_setup(icecast_data *icecast, mix_modes mixmode);
 void disable_device_outputs(device_t *dev);
 void disable_channel_outputs(channel_t *channel);
 void *output_check_thread(void* params);
-void *output_thread(void* params);
+void *device_output_thread(void* params);
+void *mixer_output_thread(void* params);
 
 // rtl_airband.cpp
 extern bool use_localtime;
@@ -336,8 +337,10 @@ extern volatile int do_exit, device_opened;
 extern float alpha;
 extern device_t *devices;
 extern mixer_t *mixers;
-extern pthread_cond_t mp3_cond;
-extern pthread_mutex_t mp3_mutex;
+extern pthread_cond_t device_mp3_cond;
+extern pthread_mutex_t device_mp3_mutex;
+extern pthread_cond_t mixer_mp3_cond;
+extern pthread_mutex_t mixer_mp3_mutex;
 
 // util.cpp
 void error();


### PR DESCRIPTION
Added configuration flag `multiple_output_threads` (defaulted to `false`) that will create an output thread per device and a separate thread for all mixers (if any).

This is done by moving the mp3 condition and mutex variables from globals to objects of a new class `Signal`, modifying `output_thread()` to operate on select device / mixer ranges, and connecting device/mixer thread(s) to output thread(s).