### PR TITLE
Add squelch debug output file

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -211,11 +211,7 @@ static struct freq_t *mk_freqlist( int n )
 		fl[i].frequency = 0;
 		fl[i].label = NULL;
 		fl[i].agcavgfast = 0.5f;
-		fl[i].agcavgslow = 0.5f;
-		fl[i].filter_avg = 0.5f;
-		fl[i].agcmin = 100.0f;
-		fl[i].agclow = 0;
-		fl[i].sqlevel = -1;
+		fl[i].squelch = Squelch();
 		fl[i].active_counter = 0;
 	}
 	return fl;
@@ -258,7 +254,6 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			channel->wavein[k] = 20;
 			channel->waveout[k] = 0.5;
 		}
-		channel->agcsq = 1;
 		channel->axcindicate = NO_SIGNAL;
 		channel->modulation = MOD_AM;
 		channel->mode = MM_MONO;
@@ -331,7 +326,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			if(libconfig::Setting::TypeList == chans[j]["squelch"].getType()) {
 				// New-style array of per-frequency squelch settings
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].sqlevel = (int)chans[j]["squelch"][f];
+					channel->freqlist[f].squelch = Squelch((int)chans[j]["squelch"][f]);
 				}
 				// NB: no value check; -1 allows auto-squelch for
 				//     some frequencies and not others.
@@ -343,7 +338,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 					error();
 				}
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].sqlevel = sqlevel;
+					channel->freqlist[f].squelch = Squelch(sqlevel);
 				}
 			} else {
 				cerr<<"Invalid value for squelch (should be int or list - use parentheses)\n";

--- a/config.cpp
+++ b/config.cpp
@@ -477,6 +477,16 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			debug_print("dev[%d].chan[%d]: dm_dphi_scaled=%f cast=0x%x\n", i, jj, dm_dphi, channel->dm_dphi);
 			channel->dm_phi = 0.f;
 		}
+
+		// Setup squelch debug file, if enabled
+		if (Squelch::debug_enabled()) {
+			char tmp_filepath[1024];
+			for(int f = 0; f < channel->freq_count; f++) {
+				snprintf(tmp_filepath, sizeof(tmp_filepath), "./squelch_debug-%d-%d.dat", j, f);
+				channel->freqlist[f].squelch.set_debug_file(tmp_filepath);
+			}
+		}
+
 		jj++;
 	}
 	return jj;

--- a/config.cpp
+++ b/config.cpp
@@ -478,14 +478,14 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			channel->dm_phi = 0.f;
 		}
 
+#ifdef DEBUG_SQUELCH
 		// Setup squelch debug file, if enabled
-		if (Squelch::debug_enabled()) {
-			char tmp_filepath[1024];
-			for(int f = 0; f < channel->freq_count; f++) {
-				snprintf(tmp_filepath, sizeof(tmp_filepath), "./squelch_debug-%d-%d.dat", j, f);
-				channel->freqlist[f].squelch.set_debug_file(tmp_filepath);
-			}
+		char tmp_filepath[1024];
+		for(int f = 0; f < channel->freq_count; f++) {
+			snprintf(tmp_filepath, sizeof(tmp_filepath), "./squelch_debug-%d-%d.dat", j, f);
+			channel->freqlist[f].squelch.set_debug_file(tmp_filepath);
 		}
+#endif
 
 		jj++;
 	}

--- a/input-file.cpp
+++ b/input-file.cpp
@@ -71,7 +71,7 @@ int file_init(input_t * const input) {
 
 	dev_data->input_file = fopen(dev_data->filepath, "rb");
 	if(!dev_data->input_file) {
-		cerr << "File input failed to open '" << dev_data->filepath << "'\n";
+		cerr << "File input failed to open '" << dev_data->filepath << "' - " << strerror(errno) << endl;
 		error();
 	}
 

--- a/makefile
+++ b/makefile
@@ -9,6 +9,9 @@ export DEBUG ?= 0
 export WITH_RTLSDR ?= 1
 export CC = g++
 export CFLAGS = -O3 -g -Wall -Wextra -DSYSCONFDIR=\"$(SYSCONFDIR)\" -DDEBUG=$(DEBUG)
+ifeq ($(DEBUG_SQUELCH), 1)
+  CFLAGS += -DDEBUG_SQUELCH
+endif
 RTL_AIRBAND_VERSION:=\"$(shell git describe --always --tags --dirty 2>/dev/null)\"
 ifneq ($(RTL_AIRBAND_VERSION), \"\")
   CFLAGS+=-DRTL_AIRBAND_VERSION=$(RTL_AIRBAND_VERSION)

--- a/makefile
+++ b/makefile
@@ -32,27 +32,27 @@ UNKNOWN_PLATFORM = 0
 ifeq ($(PLATFORM), rpiv1)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -ffast-math 
+  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -fno-fast-math 
   LDLIBS += -lbcm_host -ldl
   LDFLAGS += -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_vfp.o
 else ifeq ($(PLATFORM), rpiv2)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -fno-fast-math 
   LDLIBS += -lbcm_host -ldl
   LDFLAGS += -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_neon.o
 else ifeq ($(PLATFORM), armv7-generic)
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -fno-fast-math 
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), armv8-generic)
-  CFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -ffast-math
+  CFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -fno-fast-math
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), native)
-  CFLAGS += -march=native -mtune=native -ffast-math
+  CFLAGS += -march=native -mtune=native -fno-fast-math
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), x86)

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ SUBDIRS = hello_fft
 CLEANDIRS = $(SUBDIRS:%=clean-%)
 
 BIN = rtl_airband
-OBJ = rtl_airband.o input-common.o input-helpers.o input-file.o output.o config.o util.o mixer.o
+OBJ = rtl_airband.o input-common.o input-helpers.o input-file.o output.o config.o util.o mixer.o squelch.o
 FFT = hello_fft/hello_fft.a
 
 .PHONY: all clean install help $(SUBDIRS) $(CLEANDIRS)
@@ -129,7 +129,7 @@ help:
 
 $(FFT):	hello_fft ;
 
-config.o: rtl_airband.h input-common.h
+config.o: rtl_airband.h input-common.h squelch.h
 
 input-common.o: input-common.h
 
@@ -145,13 +145,15 @@ input-file.o: rtl_airband.h input-common.h input-helpers.h input-file.h
 
 mixer.o: rtl_airband.h
 
-rtl_airband.o: rtl_airband.h input-common.h
+rtl_airband.o: rtl_airband.h input-common.h squelch.h
 
 output.o: rtl_airband.h input-common.h
 
 pulse.o: rtl_airband.h
 
 util.o: rtl_airband.h
+
+squelch.o : squelch.h
 
 $(SUBDIRS):
 	$(MAKE) -C $@

--- a/makefile
+++ b/makefile
@@ -32,27 +32,27 @@ UNKNOWN_PLATFORM = 0
 ifeq ($(PLATFORM), rpiv1)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -fno-fast-math 
+  CFLAGS += -mcpu=arm1176jzf-s -mtune=arm1176jzf-s -march=armv6zk -mfpu=vfp -ffast-math 
   LDLIBS += -lbcm_host -ldl
   LDFLAGS += -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_vfp.o
 else ifeq ($(PLATFORM), rpiv2)
   CFLAGS += -DUSE_BCM_VC
   CFLAGS += -I/opt/vc/include  -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -fno-fast-math 
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
   LDLIBS += -lbcm_host -ldl
   LDFLAGS += -L/opt/vc/lib
   DEPS = $(OBJ) $(FFT) rtl_airband_neon.o
 else ifeq ($(PLATFORM), armv7-generic)
-  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -fno-fast-math 
+  CFLAGS += -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math 
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), armv8-generic)
-  CFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -fno-fast-math
+  CFLAGS += -march=armv8-a+crc -mtune=cortex-a53 -ffast-math
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), native)
-  CFLAGS += -march=native -mtune=native -fno-fast-math
+  CFLAGS += -march=native -mtune=native -ffast-math
   LDLIBS += -lfftw3f
   DEPS = $(OBJ)
 else ifeq ($(PLATFORM), x86)

--- a/output.cpp
+++ b/output.cpp
@@ -579,7 +579,7 @@ static void output_channel_noise_levels(FILE *f) {
 			channel_t* channel = devices[i].channels + j;
 			for (int k = 0; k < channel->freq_count; k++) {
 				print_channel_metric(f, "channel_noise_level", channel->freqlist[k].frequency, channel->freqlist[k].label);
-				fprintf(f, "\t%.3f\n", channel->freqlist[k].agcmin);
+				fprintf(f, "\t%.3f\n", channel->freqlist[k].squelch.noise_floor());
 			}
 		}
 	}

--- a/output.cpp
+++ b/output.cpp
@@ -586,6 +586,23 @@ static void output_channel_noise_levels(FILE *f) {
 	fprintf(f, "\n");
 }
 
+static void output_channel_squelch_counter(FILE *f) {
+	fprintf(f, "# HELP channel_squelch_counter Number of times squelch opened\n"
+			"# TYPE channel_squelch_counter counter\n");
+
+	for (int i = 0; i < device_count; i++) {
+		device_t* dev = devices + i;
+		for (int j = 0; j < dev->channel_count; j++) {
+			channel_t* channel = devices[i].channels + j;
+			for (int k = 0; k < channel->freq_count; k++) {
+				print_channel_metric(f, "channel_squelch_counter", channel->freqlist[k].frequency, channel->freqlist[k].label);
+				fprintf(f, "\t%zu\n", channel->freqlist[k].squelch.open_count());
+			}
+		}
+	}
+	fprintf(f, "\n");
+}
+
 static void output_channel_activity_counters(FILE *f) {
 	fprintf(f, "# HELP channel_activity_counter Loops of output_thread with frequency active.\n"
 			"# TYPE channel_activity_counter counter\n");
@@ -670,6 +687,7 @@ void write_stats_file(timeval *last_stats_write) {
 
 	output_channel_activity_counters(file);
 	output_channel_noise_levels(file);
+	output_channel_squelch_counter(file);
 	output_device_buffer_overflows(file);
 	output_output_overruns(file);
 	output_input_overruns(file);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -861,6 +861,8 @@ int main(int argc, char* argv[]) {
 			log_scan_activity = true;
 		if(root.exists("stats_filepath"))
 			stats_filepath = strdup(root["stats_filepath"]);
+		if(root.exists("squelch_debug_output") && (bool)root["squelch_debug_output"] == true)
+			Squelch::enable_debug(true);
 #ifdef NFM
 		if(root.exists("tau"))
 			alpha = ((int)root["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)root["tau"])));

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -861,8 +861,6 @@ int main(int argc, char* argv[]) {
 			log_scan_activity = true;
 		if(root.exists("stats_filepath"))
 			stats_filepath = strdup(root["stats_filepath"]);
-		if(root.exists("squelch_debug_output") && (bool)root["squelch_debug_output"] == true)
-			Squelch::enable_debug(true);
 #ifdef NFM
 		if(root.exists("tau"))
 			alpha = ((int)root["tau"] == 0 ? 0.0f : exp(-1.0f/(WAVE_RATE * 1e-6 * (int)root["tau"])));

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -609,7 +609,7 @@ void *demodulate(void *params) {
 								fparms->agcavgfast *= 1.15f;
 							}
 						}
-	#ifdef NFM
+#ifdef NFM
 						else if(channel->modulation == MOD_NFM) {
 							// FM demod
 							if(fm_demod == FM_FAST_ATAN2) {
@@ -625,7 +625,7 @@ void *demodulate(void *params) {
 							channel->waveout[j] -= fparms->agcavgfast;
 							channel->waveout[j] = channel->waveout[j] * (1.0f - channel->alpha) + channel->waveout[j-1] * channel->alpha;
 						}
-	#endif // NFM
+#endif // NFM
 
 						// apply the notch filter, will be a no-op if not configured
 						fparms->notch_filter.apply(channel->waveout[j]);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -54,6 +54,9 @@
 #include <cstdarg>
 #include <cerrno>
 #include <iostream>
+// TODO: remove - start
+#include <iomanip>
+// TODO: remove - end
 #include <cstring>
 #include <cstdio>
 #include <cassert>
@@ -68,6 +71,7 @@
 #include <lame/lame.h>
 #include "input-common.h"
 #include "rtl_airband.h"
+#include "squelch.h"
 
 #ifdef WITH_PROFILING
 #include "gperftools/profiler.h"
@@ -533,133 +537,117 @@ void *demodulate(void *params) {
 				AFC afc(dev, i);
 				channel_t* channel = dev->channels + i;
 				freq_t *fparms = channel->freqlist + channel->freq_idx;
+
+				// TODO: why not just do this in the loop below?
 #if defined (__arm__) || defined (__aarch64__)
-				float agcmin2 = fparms->agcmin * 4.5f;
+				float agcmin2 = fparms->squelch.noise_floor() * 4.5f;
 				for (int j = 0; j < WAVE_BATCH + AGC_EXTRA; j++) {
 					channel->waveref[j] = min(channel->wavein[j], agcmin2);
 				}
 #else
-				__m128 agccap = _mm_set1_ps(fparms->agcmin * 4.5f);
+				__m128 agccap = _mm_set1_ps(fparms->squelch.noise_floor() * 4.5f);
 				for (int j = 0; j < WAVE_BATCH + AGC_EXTRA; j += 4) {
 					__m128 t = _mm_loadu_ps(channel->wavein + j);
 					_mm_storeu_ps(channel->waveref + j, _mm_min_ps(t, agccap));
 				}
 #endif
+
 				for (int j = AGC_EXTRA; j < WAVE_BATCH + AGC_EXTRA; j++) {
-					// auto noise floor
-					if (fparms->sqlevel < 0 && j % 16 == 0) {
-						fparms->agcmin = fparms->agcmin * 0.97f + min(fparms->agcavgslow, fparms->agcmin) * 0.03f + 0.0001f;
-					}
 
-					// average power
-					fparms->agcavgslow = fparms->agcavgslow * 0.99f + channel->waveref[j] * 0.01f;
+					float &real = channel->iq_in[2*(j - AGC_EXTRA)];
+					float &imag = channel->iq_in[2*(j - AGC_EXTRA)+1];
 
-					float sqlevel = fparms->sqlevel >= 0 ? (float)fparms->sqlevel : 3.0f * fparms->agcmin;
-					if (channel->agcsq > 0) {
-						channel->agcsq = max(channel->agcsq - 1, 1);
-						if (channel->agcsq == 1 && fparms->agcavgslow > sqlevel) {
-							channel->agcsq = -AGC_EXTRA * 2;
-							channel->axcindicate = SIGNAL;
-							if(channel->modulation == MOD_AM) {
-							// fade in
-								for (int k = j - AGC_EXTRA; k < j; k++) {
-									if (channel->wavein[k] > sqlevel) {
-										fparms->agcavgfast = fparms->agcavgfast * 0.9f + channel->wavein[k] * 0.1f;
-									}
-								}
-							}
-						}
-					} else {
-						if (channel->wavein[j] > sqlevel) {
-							if(channel->modulation == MOD_AM)
-								fparms->agcavgfast = fparms->agcavgfast * 0.995f + channel->wavein[j] * 0.005f;
-							fparms->agclow = 0;
-						} else {
-							fparms->agclow++;
-						}
-						channel->agcsq = min(channel->agcsq + 1, -1);
-						if ((channel->agcsq == -1 && fparms->agcavgslow < sqlevel) || fparms->agclow == AGC_EXTRA - 12) {
-							channel->agcsq = AGC_EXTRA * 2;
-							channel->axcindicate = NO_SIGNAL;
-							if(channel->modulation == MOD_AM) {
-								// fade out
-								for (int k = j - AGC_EXTRA + 1; k < j; k++) {
-									channel->waveout[k] = channel->waveout[k - 1] * 0.94f;
-								}
-							}
-						}
-					}
+					fparms->squelch.process_reference_sample(channel->waveref[j]);
 
-					bool signal_filtered = false;
-					if(channel->agcsq < 0 && channel->needs_raw_iq) {
+					// If squelch is open / opening and using I/Q, then cleanup the signal and possibly update squelch.
+					if (fparms->squelch.should_filter_sample() && channel->needs_raw_iq) {
 						// remove phase rotation introduced by FFT sliding window
-						float swf, cwf, re, im;
+						float swf, cwf, re_tmp, im_tmp;
 						sincosf_lut(channel->dm_phi, &swf, &cwf);
-						multiply(channel->iq_in[2*(j - AGC_EXTRA)], channel->iq_in[2*(j - AGC_EXTRA)+1], cwf, -swf, &re, &im);
+						multiply(real, imag, cwf, -swf, &re_tmp, &im_tmp);
 						channel->dm_phi += channel->dm_dphi;
 						channel->dm_phi &= 0xffffff;
 
 						// apply lowpass filter, will be a no-op if not configured
-						fparms->lowpass_filter.apply(re, im);
+						fparms->lowpass_filter.apply(re_tmp, im_tmp);
 
 						// update I/Q and wave
-						channel->iq_in[2*(j - AGC_EXTRA)] = re;
-						channel->iq_in[2*(j - AGC_EXTRA)+1] = im;
-						channel->wavein[j] = sqrt(re * re + im * im);
+						real = re_tmp;
+						imag = im_tmp;
+						channel->wavein[j] = sqrt(real * real + imag * imag);
 
-						if(fparms->lowpass_filter.enabled()) {
-							fparms->filter_avg = fparms->filter_avg * 0.999f + channel->wavein[j] * 0.001f;
-
-							if (fparms->filter_avg < sqlevel) {
-								signal_filtered = true;
-								channel->axcindicate = NO_SIGNAL;
-							} else {
-								channel->axcindicate = SIGNAL;
-							}
+						// update squelch post-cleanup
+						if (fparms->lowpass_filter.enabled()) {
+							fparms->squelch.process_filtered_sample(channel->wavein[j]);
 						}
+// TODO: remove - start
+						cout << std::setprecision(10) << "filtered in: " << channel->wavein[j] << endl;
+// TODO: remove - end
 					}
-					if(channel->agcsq != -1 || signal_filtered) {
-						channel->waveout[j] = 0;
-						if(channel->has_iq_outputs) {
-							channel->iq_out[2*(j - AGC_EXTRA)] = 0;
-							channel->iq_out[2*(j - AGC_EXTRA)+1] = 0;
-						}
-					} else {
-						const float &re = channel->iq_in[2*(j - AGC_EXTRA)];
-						const float &im = channel->iq_in[2*(j - AGC_EXTRA)+1];
 
-						if(channel->has_iq_outputs) {
-							channel->iq_out[2*(j - AGC_EXTRA)] = re;
-							channel->iq_out[2*(j - AGC_EXTRA)+1] = im;
-						}
-
+					// If squelch is still open then do modulation-specific processing
+					if (fparms->squelch.is_open()) {
 						if(channel->modulation == MOD_AM) {
+							// if squelch is just opening then fade in, or if just closing fade out
+							if (fparms->squelch.get_state() == Squelch::OPENING) {
+								for (int k = j - AGC_EXTRA; k < j; k++) {
+									if (channel->wavein[k] >= fparms->squelch.squelch_level()) {
+										fparms->agcavgfast = fparms->agcavgfast * 0.9f + channel->wavein[k] * 0.1f;
+									}
+								}
+							} else if (fparms->squelch.get_state() == Squelch::CLOSING) {
+								for (int k = j - AGC_EXTRA + 1; k < j; k++) {
+									channel->waveout[k] = channel->waveout[k - 1] * 0.94f;
+								}
+							}
+
+							fparms->agcavgfast = fparms->agcavgfast * 0.995f + channel->wavein[j] * 0.005f;
 							channel->waveout[j] = (channel->wavein[j - AGC_EXTRA] - fparms->agcavgfast) / (fparms->agcavgfast * 1.5f);
 							if (abs(channel->waveout[j]) > 0.8f) {
 								channel->waveout[j] *= 0.85f;
 								fparms->agcavgfast *= 1.15f;
 							}
 						}
-#ifdef NFM
+	#ifdef NFM
 						else if(channel->modulation == MOD_NFM) {
-// FM demod
+							// FM demod
 							if(fm_demod == FM_FAST_ATAN2) {
-								channel->waveout[j] = polar_disc_fast(re, im, channel->pr, channel->pj);
+								channel->waveout[j] = polar_disc_fast(real, imag, channel->pr, channel->pj);
 							} else if(fm_demod == FM_QUADRI_DEMOD) {
-								channel->waveout[j] = fm_quadri_demod(re, im, channel->pr, channel->pj);
+								channel->waveout[j] = fm_quadri_demod(real, imag, channel->pr, channel->pj);
 							}
-							channel->pr = re;
-							channel->pj = im;
-// de-emphasis IIR + DC blocking
+							channel->pr = real;
+							channel->pj = imag;
+
+							// de-emphasis IIR + DC blocking
 							fparms->agcavgfast = fparms->agcavgfast * 0.995f + channel->waveout[j] * 0.005f;
 							channel->waveout[j] -= fparms->agcavgfast;
 							channel->waveout[j] = channel->waveout[j] * (1.0f - channel->alpha) + channel->waveout[j-1] * channel->alpha;
 						}
-#endif // NFM
+	#endif // NFM
 
-// apply the notch filter.  If no filter configured, this will no-op
+						// apply the notch filter, will be a no-op if not configured
 						fparms->notch_filter.apply(channel->waveout[j]);
+
+						channel->axcindicate = SIGNAL;
+						if(channel->has_iq_outputs) {
+							channel->iq_out[2*(j - AGC_EXTRA)] = real;
+							channel->iq_out[2*(j - AGC_EXTRA)+1] = imag;
+						}
+
+					// Squelch is closed
+					} else {
+						channel->waveout[j] = 0;
+						// TODO: set channel->axcindicate to NO_SIGNAL at start of loop and dont clear here to allow output() to pick up the end of a transmission
+						channel->axcindicate = NO_SIGNAL;
+						if(channel->has_iq_outputs) {
+							channel->iq_out[2*(j - AGC_EXTRA)] = 0;
+							channel->iq_out[2*(j - AGC_EXTRA)+1] = 0;
+						}
 					}
+// TODO: remove - start
+					cout << std::setprecision(10) << channel->waveout[j] << endl;
+// TODO: remove - end
 				}
 				memmove(channel->wavein, channel->wavein + WAVE_BATCH, (dev->waveend - WAVE_BATCH) * sizeof(float));
 				if(channel->needs_raw_iq) {
@@ -675,16 +663,18 @@ void *demodulate(void *params) {
 				if (tui) {
 					if(dev->mode == R_SCAN) {
 						GOTOXY(0, device_num * 17 + dev->row + 3);
+						// TODO: change to dB
 						printf("%4.0f/%3.0f%c %7.3f ",
-							fparms->agcavgslow,
-							(fparms->sqlevel >= 0 ? fparms->sqlevel : fparms->agcmin),
+							fparms->squelch.power_level(),
+							fparms->squelch.squelch_level(),
 							channel->axcindicate,
 							(dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					} else {
 						GOTOXY(i*10, device_num * 17 + dev->row + 3);
+						// TODO: change to dB
 						printf("%4.0f/%3.0f%c ",
-							fparms->agcavgslow,
-							(fparms->sqlevel >= 0 ? fparms->sqlevel : fparms->agcmin),
+							fparms->squelch.power_level(),
+							fparms->squelch.squelch_level(),
 							channel->axcindicate);
 					}
 					fflush(stdout);

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -38,6 +38,7 @@
 #include <pulse/stream.h>
 #endif
 #include "input-common.h"	// input_t
+#include "squelch.h"
 
 #ifndef RTL_AIRBAND_VERSION
 #define RTL_AIRBAND_VERSION "3.1.0"
@@ -240,11 +241,7 @@ struct freq_t {
 	int frequency;				// scan frequency
 	char *label;				// frequency label
 	float agcavgfast;			// average power, for AGC
-	float agcavgslow;			// average power, for squelch level detection
-	float filter_avg;			// average power, for post-filter squelch level detection
-	float agcmin;				// noise level
-	int sqlevel;				// manually configured squelch level
-	int agclow;					// low level sample count
+	Squelch squelch;
 	size_t active_counter;		// count of loops where channel has signal
 	NotchFilter notch_filter;	// notch filter - good to remove CTCSS tones
 	LowpassFilter lowpass_filter;	// lowpass filter, applied to I/Q after derotation, set at bandwidth/2 to remove out of band noise
@@ -264,7 +261,6 @@ struct channel_t {
 	uint32_t dm_dphi, dm_phi;	// derotation frequency and current phase value
 	enum modulations modulation;
 	enum mix_modes mode;		// mono or stereo
-	int agcsq;					// squelch status, negative: signal, positive: suppressed
 	status axcindicate;
 	unsigned char afc;			//0 - AFC disabled; 1 - minimal AFC; 2 - more aggressive AFC and so on to 255
 	struct freq_t *freqlist;

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -4,10 +4,6 @@
 
 using namespace std;
 
-static const float DECAY_FACTOR = 0.998125f;
-static const float UPDATE_FACTOR = 1.0f - DECAY_FACTOR;
-static const float NOISE_FLOOR_GROWTH = 0.00000625f;
-
 Squelch::Squelch(int manual) :
 	manual_(manual)
 {
@@ -15,9 +11,12 @@ Squelch::Squelch(int manual) :
 	pre_filter_avg_ = 0.5f;
 	post_filter_avg_ = 0.5f;
 
+	using_post_filter_ = false;
+
 	// TODO: Possible Improvement - revisit magic numbers
-	flap_delay_ = AGC_EXTRA * 2 - 1;
-	low_power_abort_ = AGC_EXTRA - 12;
+	open_delay_ = 197;
+	close_delay_ = 197;
+	low_power_abort_ = 88;
 
 	next_state_ = CLOSED;
 	current_state_ = CLOSED;
@@ -27,7 +26,7 @@ Squelch::Squelch(int manual) :
 	sample_count_ = 0;
 	low_power_count_ = 0;
 
-	debug_print("Created Squelch, flap_delay: %d, low_power_abort: %d, manual: %d\n", flap_delay_, low_power_abort_, manual_);
+	debug_print("Created Squelch, open_delay_: %d, close_delay_: %d, low_power_abort: %d, manual: %d\n", open_delay_, close_delay_, low_power_abort_, manual_);
 }
 
 bool Squelch::is_open(void) const {
@@ -35,17 +34,14 @@ bool Squelch::is_open(void) const {
 }
 
 bool Squelch::should_filter_sample(void) const {
-	if (current_state_ == OPEN || current_state_ == OPENING) {
-		return true;
-	}
-	return false;
+	return (current_state_ == OPEN || current_state_ == OPENING);
 }
 
-bool Squelch::should_fade_in(void) const {
+bool Squelch::first_open_sample(void) const {
 	return (next_state_ == OPENING && current_state_ != OPENING);
 }
 
-bool Squelch::should_fade_out(void) const {
+bool Squelch::last_open_sample(void) const {
 	return (next_state_ == CLOSING && current_state_ != CLOSING);
 }
 
@@ -77,6 +73,9 @@ bool Squelch::is_manual(void) const {
 }
 
 bool Squelch::has_power(void) const {
+	if (using_post_filter_) {
+		return power_level() >= squelch_level() && post_filter_avg_ >= pre_filter_avg_;
+	}
 	return power_level() >= squelch_level();
 }
 
@@ -87,10 +86,15 @@ void Squelch::process_reference_sample(const float &sample) {
 
 	sample_count_++;
 
-	// auto noise floor and average power
-	// TODO: what is the purpose of the NOISE_FLOOR_GROWTH?  This could account for squelch flap on marginal signal
-	noise_floor_ = noise_floor_ * DECAY_FACTOR + std::min(pre_filter_avg_, noise_floor_) * UPDATE_FACTOR + NOISE_FLOOR_GROWTH;
-	pre_filter_avg_ = pre_filter_avg_ * DECAY_FACTOR + sample * UPDATE_FACTOR;
+	// auto noise floor
+	// TODO: Possible Improvement - update noise floor with each sample
+	// TODO: what is the purpose of the adding 0.0001f every loop?  This could account for squelch flap on marginal signal
+	if (sample_count_ % 16 == 0) {
+		noise_floor_ = noise_floor_ * 0.97f + std::min(pre_filter_avg_, noise_floor_) * 0.03f + 0.0001f;
+	}
+
+	// average power
+	pre_filter_avg_ = pre_filter_avg_ * 0.99f + sample * 0.01f;
 
 	// Check power against thresholds
 	if (current_state_ == OPEN && has_power() == false) {
@@ -104,6 +108,7 @@ void Squelch::process_reference_sample(const float &sample) {
 	}
 
 	// Override squelch and close if there are repeated samples under the squelch level
+	// NOTE: this can cause squelch to close, but it may immediately be re-opened if the power level still hasn't fallen after the delays
 	if((current_state_ == OPEN || current_state_ == OPENING) && next_state_ != CLOSING) {
 		if (sample >= squelch_level()) {
 			low_power_count_ = 0;
@@ -123,9 +128,10 @@ void Squelch::process_filtered_sample(const float &sample) {
 	}
 
 	// average power
-	post_filter_avg_ = post_filter_avg_ * DECAY_FACTOR + sample * UPDATE_FACTOR;
+	using_post_filter_ = true;
+	post_filter_avg_ = post_filter_avg_ * 0.999f + sample * 0.001f;
 
-	if ((current_state_ == OPEN || current_state_ == OPENING || next_state_ == OPEN || next_state_ == OPENING) && post_filter_avg_ < squelch_level()) {
+	if ((current_state_ == OPEN || current_state_ == OPENING || next_state_ == OPEN || next_state_ == OPENING) && post_filter_avg_ < pre_filter_avg_) {
 		debug_print("Closing at %zu: power post filter (%f < %f)\n", sample_count_, post_filter_avg_, squelch_level());
 		set_state(CLOSING);
 	}
@@ -179,12 +185,14 @@ void Squelch::set_state(State update) {
 void Squelch::update_current_state(void) {
 	if (next_state_ == OPENING) {
 		if (current_state_ != OPENING) {
+			debug_print("%zu: transitioning to OPENING\n", sample_count_);
 			open_count_++;
-			delay_ = flap_delay_;
+			delay_ = open_delay_;
 			low_power_count_ = 0;
 			post_filter_avg_ = pre_filter_avg_;
 			current_state_ = next_state_;
 		} else {
+			// in OPENING delay
 			delay_--;
 			if (delay_ <= 0) {
 				next_state_ = OPEN;
@@ -192,14 +200,23 @@ void Squelch::update_current_state(void) {
 		}
 	} else if (next_state_ == CLOSING) {
 		if (current_state_ != CLOSING) {
-			delay_ = flap_delay_;
+			debug_print("%zu: transitioning to CLOSING\n", sample_count_);
+			delay_ = close_delay_;
 			current_state_ = next_state_;
 		} else {
+			// in CLOSING delay
 			delay_--;
 			if (delay_ <= 0) {
 				next_state_ = CLOSED;
 			}
 		}
+	} else if (next_state_ == OPEN && current_state_ != OPEN) {
+		debug_print("%zu: transitioning to OPEN\n", sample_count_);
+		current_state_ = next_state_;
+	} else if (next_state_ == CLOSED && current_state_ != CLOSED) {
+		debug_print("%zu: transitioning to CLOSED\n", sample_count_);
+		using_post_filter_ = false;
+		current_state_ = next_state_;
 	} else {
 		current_state_ = next_state_;
 	}

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -1,0 +1,231 @@
+#include "squelch.h"
+
+// TODO: remove - start
+#include <iomanip> // needed for std::setprecision()
+// TODO: remove - end
+
+#include "rtl_airband.h" // needed for debug_print()
+
+using namespace std;
+
+Squelch::Squelch(int manual) :
+	manual_(manual)
+{
+	agcmin_ = 100.0f;
+	agcavgslow_ = 0.5f;
+	post_filter_avg_ = 0.5f;
+
+	// TODO: Possible Improvement - revisit magic numbers
+	flap_delay_ = AGC_EXTRA * 2 - 1;
+	low_power_abort_ = AGC_EXTRA - 12;
+
+	next_state_ = CLOSED;
+	current_state_ = CLOSED;
+
+	delay_ = 0;
+	open_count_ = 0;
+	sample_count_ = 0;
+	low_power_count_ = 0;
+
+	debug_print("Created Squelch, flap_delay: %d, low_power_abort: %d, manual: %d\n", flap_delay_, low_power_abort_, manual_);
+}
+
+bool Squelch::is_open(void) const {
+	// TODO: Causes Diff - remove checks on next_state_
+	return (current_state_ == OPEN && next_state_ != CLOSING);
+}
+
+bool Squelch::should_filter_sample(void) const {
+	// TODO: Causes Diff - remove checks on next_state_
+	if (next_state_ == CLOSING) {
+		return false;
+	}
+	if (current_state_ == OPEN || current_state_ == OPENING || next_state_ == OPENING) {
+		return true;
+	}
+	return false;
+}
+
+const Squelch::State & Squelch::get_state(void) const {
+	return current_state_;
+}
+
+const float & Squelch::noise_floor(void) const {
+	return agcmin_;
+}
+
+const float & Squelch::power_level(void) const {
+	return agcavgslow_;
+}
+
+const size_t & Squelch::open_count(void) const {
+	return open_count_;
+}
+
+float Squelch::squelch_level(void) const {
+	if (is_manual()) {
+		return manual_;
+	}
+	return 3.0f * noise_floor();
+}
+
+bool Squelch::is_manual(void) const {
+	return manual_ >= 0;
+}
+
+bool Squelch::has_power(void) const {
+	return power_level() >= squelch_level();
+}
+
+void Squelch::process_reference_sample(const float &sample) {
+
+	// Update current state based on previous state from last iteration
+	update_current_state();
+
+	sample_count_++;
+
+	// auto noise floor
+	// TODO: Possible Improvement - update noise floor with each sample
+	// TODO: Causes Diff - remove +3
+	if ((sample_count_ + 3) % 16 == 0) {
+		agcmin_ = agcmin_ * 0.97f + std::min(agcavgslow_, agcmin_) * 0.03f + 0.0001f;
+	}
+
+	// TODO: remove - start
+	cout << sample_count_ << ": sample - " << sample << " agcavgslow - " << agcavgslow_ << " agcmin - " << agcmin_ << " delay - " << delay_ << endl;
+	cout << std::setprecision(10) << agcavgslow_ << " * " << 0.99f << " + " << sample << " * " << 0.01f << endl;
+	// TODO: remove - end
+
+	// average power
+	agcavgslow_ = agcavgslow_ * 0.99f + sample * 0.01f;
+
+	// Check power against thresholds
+	if (current_state_ == OPEN && has_power() == false) {
+// TODO: remove - start
+		cout << sample_count_ << ": no power after timeout (" << power_level() << " < " << squelch_level() << "), closing\n";
+// TODO: remove - end
+		debug_print("Closing at %zu: no power after timeout (%f < %f)\n", sample_count_, power_level(), squelch_level());
+		set_state(CLOSING);
+	}
+
+	if (current_state_ == CLOSED && has_power() == true) {
+// TODO: remove - start
+		cout << sample_count_ << ": power (" << power_level() << " > " << squelch_level() << "), opening\n";
+// TODO: remove - end
+		debug_print("Opening at %zu: power (%f >= %f)\n", sample_count_, power_level(), squelch_level());
+		set_state(OPENING);
+	}
+
+	// Override squelch and close if there are repeated samples under the squelch level
+	// TODO: what about current state being OPENING?
+	if((current_state_ == OPEN || current_state_ == OPENING) && next_state_ != CLOSING) {
+		if (sample >= squelch_level()) {
+			low_power_count_ = 0;
+		} else {
+			low_power_count_++;
+			if (low_power_count_ >= low_power_abort_) {
+// TODO: remove - start
+				cout << sample_count_ << ": no power after timeout (" << power_level() << " < " << squelch_level() << "), closing\n";
+// TODO: remove - end
+				debug_print("Closing at %zu: low power count %d\n", sample_count_, low_power_count_);
+				set_state(CLOSING);
+			}
+		}
+	}
+}
+
+void Squelch::process_filtered_sample(const float &sample) {
+	if (should_filter_sample() == false) {
+		return;
+	}
+
+	// average power
+	post_filter_avg_ = post_filter_avg_ * 0.999f + sample * 0.001f;
+
+	if (delay_ == 0 && post_filter_avg_ < squelch_level()) {
+// TODO: remove - start
+		cout << sample_count_ << ": post filter (" << post_filter_avg_ << " < " << squelch_level() << "), closing\n";
+// TODO: remove - end
+		debug_print("Closing at %zu: power post filter (%f < %f)\n", sample_count_, post_filter_avg_, squelch_level());
+		set_state(CLOSING);
+	}
+}
+
+void Squelch::set_state(State update) {
+
+	// Valid transitions (current_state_ -> next_state_) are:
+	//  - OPENING -> OPENING
+	//  - OPENING -> CLOSING
+	//  - OPENING -> OPEN
+	//  - OPEN -> OPEN
+	//  - OPEN -> CLOSING
+	//  - CLOSING -> OPENING
+	//  - CLOSING -> CLOSING
+	//  - CLOSING -> CLOSED
+	//  - CLOSED -> CLOSED
+	//  - CLOSED -> OPENING
+
+	// Invalid transistions (current_state_ -> next_state_) are:
+	//  - OPENING -> CLOSED (must go through CLOSING to get to CLOSED)
+	//  - OPEN -> OPENING (if already OPEN cant go backwards)
+	//  - OPEN -> CLOSED (must go through CLOSING to get to CLOSED)
+	//  - CLOSING -> OPEN (must go through OPENING to get to OPEN)
+	//  - CLOSED -> CLOSING (if already CLOSED cant go backwards)
+	//  - CLOSED -> OPEN (must go through OPENING to get to OPEN)
+
+	// must go through OPENING to get to OPEN (unless already OPEN)
+	if (update == OPEN && current_state_ != OPEN && current_state_ != OPENING) {
+		update = OPENING;
+	}
+
+	// must go through CLOSING to get to CLOSED (unless already CLOSED)
+	if (update == CLOSED && current_state_ != CLOSING && current_state_ != CLOSED) {
+		update = CLOSING;
+	}
+
+	// if already OPEN cant go backwards
+	if (update == OPENING && current_state_ == OPEN) {
+		update = OPEN;
+	}
+
+	// if already CLOSED cant go backwards
+	if (update == CLOSING && current_state_ == CLOSED) {
+		update = CLOSED;
+	}
+
+	next_state_ = update;
+}
+
+void Squelch::update_current_state(void) {
+	if (next_state_ == OPENING) {
+		if (current_state_ != OPENING) {
+			open_count_++;
+			delay_ = flap_delay_;
+			low_power_count_ = 0;
+			// TODO: Causes Diff - re-initialize post_filter_avg_ = agcavgslow_
+			current_state_ = next_state_;
+		} else {
+			delay_--;
+			// TODO: Causes Diff - remove start
+			if (delay_ == 2) {
+				delay_ = 0;
+			}
+			// TODO: Causes Diff - remove end
+			if (delay_ <= 2) {
+				next_state_ = OPEN;
+			}
+		}
+	} else if (next_state_ == CLOSING) {
+		if (current_state_ != CLOSING) {
+			delay_ = flap_delay_;
+			current_state_ = next_state_;
+		} else {
+			delay_--;
+			if (delay_ == 0) {
+				next_state_ = CLOSED;
+			}
+		}
+	} else {
+		current_state_ = next_state_;
+	}
+}

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -1,5 +1,7 @@
 #include "squelch.h"
 
+#include <string.h> // needed for strerror()
+
 #include "rtl_airband.h" // needed for debug_print()
 
 using namespace std;
@@ -26,7 +28,15 @@ Squelch::Squelch(int manual) :
 	sample_count_ = 0;
 	low_power_count_ = 0;
 
+	debug_file_ = NULL;
+
 	debug_print("Created Squelch, open_delay_: %d, close_delay_: %d, low_power_abort: %d, manual: %d\n", open_delay_, close_delay_, low_power_abort_, manual_);
+}
+
+Squelch::~Squelch(void) {
+	if (debug_file_) {
+		fclose(debug_file_);
+	}
 }
 
 bool Squelch::is_open(void) const {
@@ -120,6 +130,8 @@ void Squelch::process_reference_sample(const float &sample) {
 			}
 		}
 	}
+
+	debug_value(sample);
 }
 
 void Squelch::process_filtered_sample(const float &sample) {
@@ -220,4 +232,113 @@ void Squelch::update_current_state(void) {
 	} else {
 		current_state_ = next_state_;
 	}
+
+	// dont write state the very first time process_reference_sample() has been called
+	if (sample_count_ != 0 || open_count_ != 0) {
+		debug_state();
+	}
+}
+
+/*
+ Debug file methods
+ ==================
+
+ Values written to file are:
+	 - (int16_t) process_reference_sample input
+	 - (int16_t) noise_floor_
+	 - (int16_t) pre_filter_avg_
+	 - (int16_t) post_filter_avg_
+	 - (int) current_state_
+	 - (int) delay_
+	 - (int) low_power_count_
+
+  The output file can be read / plotted in python as follows:
+
+	import matplotlib.pyplot as plt
+	import numpy as np
+
+	def plot_squelch_debug(filepath):
+
+		dt = np.dtype([('reference_input', np.single),
+					   ('noise_floor', np.single),
+					   ('pre_filter_avg', np.single),
+					   ('post_filter_avg', np.single),
+					   ('current_state', np.intc),
+					   ('delay', np.intc),
+					   ('low_power_count', np.intc)
+					  ])
+
+		dat = np.fromfile(filepath, dtype=dt)
+
+		plt.figure()
+		plt.plot(dat['reference_input'], 'b')
+		plt.plot(dat['pre_filter_avg'], 'g')
+		plt.plot(dat['noise_floor'], 'r')
+		plt.show(block=False)
+
+		plt.figure()
+		plt.plot(dat['post_filter_avg'], 'k')
+		plt.show(block=False)
+
+		plt.figure()
+		axis = plt.subplot2grid((3, 1), (0, 0))
+		axis.plot(dat['current_state'], 'c')
+		axis = plt.subplot2grid((3, 1), (1, 0))
+		axis.plot(dat['delay'], 'm')
+		axis = plt.subplot2grid((3, 1), (2, 0))
+		axis.plot(dat['low_power_count'], 'y')
+		plt.show(block=False)
+
+		return
+
+  */
+
+bool Squelch::debug_enabled_ = false;
+
+void Squelch::enable_debug(bool value) {
+	debug_enabled_ = value;
+}
+
+bool Squelch::debug_enabled(void) {
+	return debug_enabled_;
+}
+
+void Squelch::set_debug_file(const char *filepath) {
+	if (debug_enabled_) {
+		debug_file_ = fopen(filepath, "wb");
+
+	}
+}
+
+void Squelch::debug_value(const float &value) {
+	if (!debug_enabled_ || !debug_file_) {
+		return;
+	}
+
+	if (fwrite(&value, sizeof(value), 1, debug_file_) != sizeof(value)) {
+		debug_print("Error writing to squelch debug file: %s\n", strerror(errno));
+	}
+}
+
+void Squelch::debug_value(const int &value) {
+	if (!debug_file_ || !debug_enabled_) {
+		return;
+	}
+
+	if (fwrite(&value, sizeof(value), 1, debug_file_) != sizeof(value)) {
+		debug_print("Error writing to squelch debug file: %s\n", strerror(errno));
+	}
+}
+
+void Squelch::debug_state(void) {
+	if (!debug_file_ || !debug_enabled_) {
+		return;
+	}
+
+	debug_value(noise_floor_);
+	debug_value(pre_filter_avg_);
+	debug_value(post_filter_avg_);
+	debug_value((int)current_state_);
+	debug_value(delay_);
+	debug_value(low_power_count_);
 }

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -1,6 +1,8 @@
 #include "squelch.h"
 
+#ifdef DEBUG_SQUELCH
 #include <string.h> // needed for strerror()
+#endif
 
 #include "rtl_airband.h" // needed for debug_print()
 
@@ -28,15 +30,11 @@ Squelch::Squelch(int manual) :
 	sample_count_ = 0;
 	low_power_count_ = 0;
 
+#ifdef DEBUG_SQUELCH
 	debug_file_ = NULL;
+#endif
 
 	debug_print("Created Squelch, open_delay_: %d, close_delay_: %d, low_power_abort: %d, manual: %d\n", open_delay_, close_delay_, low_power_abort_, manual_);
-}
-
-Squelch::~Squelch(void) {
-	if (debug_file_) {
-		fclose(debug_file_);
-	}
 }
 
 bool Squelch::is_open(void) const {
@@ -131,7 +129,9 @@ void Squelch::process_reference_sample(const float &sample) {
 		}
 	}
 
+#ifdef DEBUG_SQUELCH
 	debug_value(sample);
+#endif
 }
 
 void Squelch::process_filtered_sample(const float &sample) {
@@ -233,12 +233,16 @@ void Squelch::update_current_state(void) {
 		current_state_ = next_state_;
 	}
 
+#ifdef DEBUG_SQUELCH
 	// dont write state the very first time process_reference_sample() has been called
 	if (sample_count_ != 0 || open_count_ != 0) {
 		debug_state();
 	}
+#endif
 }
 
+
+#ifdef DEBUG_SQUELCH
 /*
  Debug file methods
  ==================
@@ -293,25 +297,18 @@ void Squelch::update_current_state(void) {
 
   */
 
-bool Squelch::debug_enabled_ = false;
-
-void Squelch::enable_debug(bool value) {
-	debug_enabled_ = value;
-}
-
-bool Squelch::debug_enabled(void) {
-	return debug_enabled_;
-}
-
-void Squelch::set_debug_file(const char *filepath) {
-	if (debug_enabled_) {
-		debug_file_ = fopen(filepath, "wb");
-
+Squelch::~Squelch(void) {
+	if (debug_file_) {
+		fclose(debug_file_);
 	}
 }
 
+void Squelch::set_debug_file(const char *filepath) {
+	debug_file_ = fopen(filepath, "wb");
+}
+
 void Squelch::debug_value(const float &value) {
-	if (!debug_enabled_ || !debug_file_) {
+	if (!debug_file_) {
 		return;
 	}
 
@@ -321,7 +318,7 @@ void Squelch::debug_value(const float &value) {
 }
 
 void Squelch::debug_value(const int &value) {
-	if (!debug_file_ || !debug_enabled_) {
+	if (!debug_file_) {
 		return;
 	}
 
@@ -331,7 +328,7 @@ void Squelch::debug_value(const int &value) {
 }
 
 void Squelch::debug_state(void) {
-	if (!debug_file_ || !debug_enabled_) {
+	if (!debug_file_) {
 		return;
 	}
 
@@ -342,3 +339,5 @@ void Squelch::debug_state(void) {
 	debug_value(delay_);
 	debug_value(low_power_count_);
 }
+
+#endif // DEBUG_SQUELCH

--- a/squelch.h
+++ b/squelch.h
@@ -1,7 +1,9 @@
 #ifndef _SQUELCH_H
 #define _SQUELCH_H
 
-#include <cstddef> // needed for size_t
+#include <stdio.h>  // needed for debug file output
+#include <cstddef>  // needed for size_t
+#include <stdint.h> // needed for int16_t
 
 /*
  Theory of operation:
@@ -37,13 +39,14 @@ class Squelch {
 public:
 
 	enum State {
+		CLOSED,		// Audio is suppressed
 		OPENING,	// Transitioning closed -> open
-		OPEN,		// Audio not suppressed
 		CLOSING,	// Transitioning open -> closed
-		CLOSED		// Audio is suppressed
+		OPEN		// Audio not suppressed
 	};
 
 	Squelch(int manual = -1);
+	~Squelch(void);
 
 	void process_reference_sample(const float &sample);
 	void process_filtered_sample(const float &sample);
@@ -59,6 +62,10 @@ public:
 	const float & power_level(void) const;
 	const size_t & open_count(void) const;
 	float squelch_level(void) const;
+
+	static void enable_debug(bool value);
+	static bool debug_enabled(void);
+	void set_debug_file(const char *filepath);
 
 private:
 	int open_delay_;			// how long to wait after power crosses squelch to open
@@ -84,6 +91,12 @@ private:
 	void update_current_state(void);
 	bool has_power(void) const;
 	bool is_manual(void) const;
+
+	static bool debug_enabled_;
+	FILE *debug_file_;
+	void debug_value(const float &value);
+	void debug_value(const int &value);
+	void debug_state(void);
 };
 
 #endif

--- a/squelch.h
+++ b/squelch.h
@@ -21,6 +21,9 @@ public:
 	bool is_open(void) const;
 	bool should_filter_sample(void) const;
 
+	bool should_fade_in(void) const;
+	bool should_fade_out(void) const;
+
 	const State & get_state(void) const;
 	const float & noise_floor(void) const;
 	const float & power_level(void) const;

--- a/squelch.h
+++ b/squelch.h
@@ -3,6 +3,36 @@
 
 #include <cstddef> // needed for size_t
 
+/*
+ Theory of operation:
+
+ Squelch has 4 states, OPEN (has audio), CLOSED (no audio), OPENING (transitioning from CLOSED to OPEN) and
+ CLOSING (transitioning from OPEN to CLOSED)
+
+ Noise floor is computed using a low pass filter and updated with the current sample or prior value, whatever
+ is lower.
+
+ Low pass filters are also used to track the current power levels.  One power level is for the sample before
+ filtering, the second for post signal filtering (if any).  The pre-filter power level is updated for every
+ sample.  The post-filter power level is optional.  When used, the post-filter power level is initialized to
+ the pre-filter value each time state transitions to OPENING, and is not updated while state is CLOSING or
+ CLOSED.
+
+ Squelch level can be set manually or is computed as a function of the noise floor.
+
+ When the power level exceeds the squelch level, the state transitions to OPENING and a delay counter starts,
+ then once the counter is over the state moves to OPEN. The same (but opposite) happens when the power level
+ drops below the squelch level.
+
+ While the squelch is OPEN, a count of continuous samples that are below the squelch level is maintained.  If
+ this count exceeds a threshold then the state moves to CLOSING.  This allows the squelch to close after a
+ sharp drop off in power before the power level has caught up.
+
+ When using a post-filter power level it can not be compared directly to the squelch level.  It can however be
+ compared to the pre-filter power level.
+ 
+ */
+
 class Squelch {
 public:
 
@@ -21,8 +51,8 @@ public:
 	bool is_open(void) const;
 	bool should_filter_sample(void) const;
 
-	bool should_fade_in(void) const;
-	bool should_fade_out(void) const;
+	bool first_open_sample(void) const;
+	bool last_open_sample(void) const;
 
 	const State & get_state(void) const;
 	const float & noise_floor(void) const;
@@ -31,13 +61,16 @@ public:
 	float squelch_level(void) const;
 
 private:
-	int flap_delay_;			// how long to wait after opening/closing before changing
+	int open_delay_;			// how long to wait after power crosses squelch to open
+	int close_delay_;			// how long to wait after power crosses squelch to close
 	int low_power_abort_;		// number of repeated samples below squelch to cause a close
 	int manual_;				// manually configured squelch level, < 0 for disabled
 
 	float noise_floor_;			// noise level
-	float pre_filter_avg_;			// average power for reference sample
+	float pre_filter_avg_;		// average power for reference sample
 	float post_filter_avg_;		// average power for post-filter sample
+
+	bool using_post_filter_;	// if the caller is providing filtered samples
 
 	State next_state_;
 	State current_state_;

--- a/squelch.h
+++ b/squelch.h
@@ -1,9 +1,11 @@
 #ifndef _SQUELCH_H
 #define _SQUELCH_H
 
+#include <cstddef> // needed for size_t
+
+#ifdef DEBUG_SQUELCH
 #include <stdio.h>  // needed for debug file output
-#include <cstddef>  // needed for size_t
-#include <stdint.h> // needed for int16_t
+#endif
 
 /*
  Theory of operation:
@@ -46,7 +48,6 @@ public:
 	};
 
 	Squelch(int manual = -1);
-	~Squelch(void);
 
 	void process_reference_sample(const float &sample);
 	void process_filtered_sample(const float &sample);
@@ -63,9 +64,10 @@ public:
 	const size_t & open_count(void) const;
 	float squelch_level(void) const;
 
-	static void enable_debug(bool value);
-	static bool debug_enabled(void);
+#ifdef DEBUG_SQUELCH
+	~Squelch(void);
 	void set_debug_file(const char *filepath);
+#endif
 
 private:
 	int open_delay_;			// how long to wait after power crosses squelch to open
@@ -92,11 +94,12 @@ private:
 	bool has_power(void) const;
 	bool is_manual(void) const;
 
-	static bool debug_enabled_;
+#ifdef DEBUG_SQUELCH
 	FILE *debug_file_;
 	void debug_value(const float &value);
 	void debug_value(const int &value);
 	void debug_state(void);
+#endif
 };
 
 #endif

--- a/squelch.h
+++ b/squelch.h
@@ -1,0 +1,56 @@
+#ifndef _SQUELCH_H
+#define _SQUELCH_H
+
+#include <iostream> // needed for std::ostream
+
+class Squelch {
+public:
+
+	enum State {
+		OPENING,	// Transitioning closed -> open
+		OPEN,		// Audio not suppressed
+		CLOSING,	// Transitioning open -> closed
+		CLOSED		// Audio is suppressed
+	};
+
+	Squelch(int manual = -1);
+
+	void process_reference_sample(const float &sample);
+	void process_filtered_sample(const float &sample);
+
+	bool is_open(void) const;
+	bool should_filter_sample(void) const;
+
+	const State & get_state(void) const;
+	const float & noise_floor(void) const;
+	const float & power_level(void) const;
+	const size_t & open_count(void) const;
+	float squelch_level(void) const;
+
+private:
+	int flap_delay_;			// how long to wait after opening/closing before changing
+	int low_power_abort_;		// number of repeated samples below squelch to cause a close
+	int manual_;				// manually configured squelch level, < 0 for disabled
+
+	float agcmin_;				// noise level
+	float agcavgslow_;			// average power for reference sample
+	float post_filter_avg_;		// average power for post-filter sample
+
+	State next_state_;
+	State current_state_;
+
+	int delay_;				// samples to wait before making next squelch decision
+	size_t open_count_;		// number of times squelch is opened
+	size_t sample_count_;	// number of samples processed (for logging)
+	int low_power_count_;	// number of repeated samples below squelch
+
+	void set_state(State update);
+	void update_current_state(void);
+	bool has_power(void) const;
+	bool is_manual(void) const;
+
+	friend std::ostream & operator << (std::ostream &out, const Squelch &squelch);
+	friend std::ostream & operator << (std::ostream &out, const Squelch::State &state);
+};
+
+#endif

--- a/squelch.h
+++ b/squelch.h
@@ -1,7 +1,7 @@
 #ifndef _SQUELCH_H
 #define _SQUELCH_H
 
-#include <iostream> // needed for std::ostream
+#include <cstddef> // needed for size_t
 
 class Squelch {
 public:
@@ -51,9 +51,6 @@ private:
 	void update_current_state(void);
 	bool has_power(void) const;
 	bool is_manual(void) const;
-
-	friend std::ostream & operator << (std::ostream &out, const Squelch &squelch);
-	friend std::ostream & operator << (std::ostream &out, const Squelch::State &state);
 };
 
 #endif

--- a/squelch.h
+++ b/squelch.h
@@ -35,8 +35,8 @@ private:
 	int low_power_abort_;		// number of repeated samples below squelch to cause a close
 	int manual_;				// manually configured squelch level, < 0 for disabled
 
-	float agcmin_;				// noise level
-	float agcavgslow_;			// average power for reference sample
+	float noise_floor_;			// noise level
+	float pre_filter_avg_;			// average power for reference sample
 	float post_filter_avg_;		// average power for post-filter sample
 
 	State next_state_;


### PR DESCRIPTION
Addition on top of #226 that adds a config option to generate debug output files for each squelch object, then the file(s) can then be loaded / plotted.

For example, here is the signal and audio output:

<img width="463" alt="Screen Shot 2021-02-08 at 6 42 49 AM" src="https://user-images.githubusercontent.com/13514783/107236392-862fd200-69da-11eb-8f83-6ac8743274bf.png">

and plotting of the debug data:

<img width="752" alt="Screen Shot 2021-02-08 at 6 38 52 AM" src="https://user-images.githubusercontent.com/13514783/107237366-82507f80-69db-11eb-86ff-0cbcebb56f6a.png">

<img width="752" alt="Screen Shot 2021-02-08 at 6 38 54 AM" src="https://user-images.githubusercontent.com/13514783/107237386-87adca00-69db-11eb-944a-249d07aedd32.png">

<img width="752" alt="Screen Shot 2021-02-08 at 6 38 57 AM" src="https://user-images.githubusercontent.com/13514783/107237406-8da3ab00-69db-11eb-81b4-f36ca73f39ec.png">



