### PR TITLE
Squelch db

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -326,7 +326,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			if(libconfig::Setting::TypeList == chans[j]["squelch"].getType()) {
 				// New-style array of per-frequency squelch settings
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch = Squelch((int)chans[j]["squelch"][f]);
+					channel->freqlist[f].squelch.set_squelch_value((int)chans[j]["squelch"][f]);
 				}
 				// NB: no value check; -1 allows auto-squelch for
 				//     some frequencies and not others.
@@ -338,10 +338,42 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 					error();
 				}
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch = Squelch(sqlevel);
+					channel->freqlist[f].squelch.set_squelch_value(sqlevel);
 				}
 			} else {
 				cerr<<"Invalid value for squelch (should be int or list - use parentheses)\n";
+				error();
+			}
+		}
+		if(chans[j].exists("squelch_db")) {
+			if(libconfig::Setting::TypeList == chans[j]["squelch_db"].getType()) {
+				// New-style array of per-frequency squelch settings
+				for(int f = 0; f<channel->freq_count; f++) {
+					channel->freqlist[f].squelch.set_squelch_db((float)chans[j]["squelch_db"][f]);
+				}
+			} else if(libconfig::Setting::TypeFloat == chans[j]["squelch_db"].getType()) {
+				// Legacy (single squelch for all frequencies)
+				for(int f = 0; f<channel->freq_count; f++) {
+					channel->freqlist[f].squelch.set_squelch_db((float)chans[j]["squelch_db"]);
+				}
+			} else {
+				cerr << "Invalid value for squelch_db (should be float or list - use parentheses)\n";
+				error();
+			}
+		}
+		if(chans[j].exists("squelch_flappy_db")) {
+			if(libconfig::Setting::TypeList == chans[j]["squelch_flappy_db"].getType()) {
+				// New-style array of per-frequency squelch settings
+				for(int f = 0; f<channel->freq_count; f++) {
+					channel->freqlist[f].squelch.set_squelch_flappy_db((float)chans[j]["squelch_flappy_db"][f]);
+				}
+			} else if(libconfig::Setting::TypeFloat == chans[j]["squelch_flappy_db"].getType()) {
+				// Legacy (single squelch for all frequencies)
+				for(int f = 0; f<channel->freq_count; f++) {
+					channel->freqlist[f].squelch.set_squelch_flappy_db((float)chans[j]["squelch_flappy_db"]);
+				}
+			} else {
+				cerr << "Invalid value for squelch_flappy_db (should be float or list - use parentheses)\n";
 				error();
 			}
 		}

--- a/config.cpp
+++ b/config.cpp
@@ -323,57 +323,71 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			dev->input->centerfreq = channel->freqlist[0].frequency + 20 * (double)(dev->input->sample_rate / fft_size);
 		}
 		if(chans[j].exists("squelch")) {
-			if(libconfig::Setting::TypeList == chans[j]["squelch"].getType()) {
+			cerr << "Warning: 'squelch' no longer supported and will be ignored, use 'squelch_level_threshold' or 'squelch_snr_threshold' instead\n";
+		}
+		if(chans[j].exists("squelch_threshold") && chans[j].exists("squelch_snr_threshold")) {
+			cerr << "Warning: Both 'squelch_threshold' and 'squelch_snr_threshold' are set and may conflict\n";
+		}
+		if(chans[j].exists("squelch_threshold")) {
+			// Value is dBFS, zero disables manual threshold (ie use auto squelch), negative is valid, positive is invalid
+			if(libconfig::Setting::TypeList == chans[j]["squelch_threshold"].getType()) {
 				// New-style array of per-frequency squelch settings
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_value((int)chans[j]["squelch"][f]);
+					float threshold_dBFS = (float)chans[j]["squelch_threshold"][f];
+					if (threshold_dBFS > 0) {
+						cerr << "Configuration error: devices.["<<i<<"] channels.["<<j<<"]: squelch_threshold must be less than or equal to 0\n";
+						error();
+					} else if (threshold_dBFS == 0) {
+						channel->freqlist[f].squelch.set_squelch_level_threshold(0);
+					} else {
+						channel->freqlist[f].squelch.set_squelch_level_threshold(dBFS_to_level(threshold_dBFS));
+					}
 				}
-				// NB: no value check; -1 allows auto-squelch for
-				//     some frequencies and not others.
-			} else if(libconfig::Setting::TypeInt == chans[j]["squelch"].getType()) {
+			} else if(libconfig::Setting::TypeInt == chans[j]["squelch_threshold"].getType()) {
 				// Legacy (single squelch for all frequencies)
-				int sqlevel = (int)chans[j]["squelch"];
-				if(sqlevel < 0) {
-					cerr<<"Configuration error: devices.["<<i<<"] channels.["<<j<<"]: squelch must be greater than 0\n";
+				float threshold_dBFS = (float)chans[j]["squelch_threshold"];
+				float level;
+				if (threshold_dBFS > 0) {
+					cerr << "Configuration error: devices.["<<i<<"] channels.["<<j<<"]: squelch_threshold must be less than or equal to 0\n";
+					error();
+				} else if (threshold_dBFS == 0) {
+					level = 0;
+				} else {
+					level = dBFS_to_level(threshold_dBFS);
+				}
+				for(int f = 0; f<channel->freq_count; f++) {
+					channel->freqlist[f].squelch.set_squelch_level_threshold(level);
+				}
+			} else {
+				cerr << "Invalid value for squelch_threshold (should be int or list - use parentheses)\n";
+				error();
+			}
+		}
+		if(chans[j].exists("squelch_snr_threshold")) {
+			// Value is SNR in dB, zero disables squelch (ie always open), positive is valid, negative is invalid
+			if(libconfig::Setting::TypeList == chans[j]["squelch_snr_threshold"].getType()) {
+				// New-style array of per-frequency squelch settings
+				for(int f = 0; f<channel->freq_count; f++) {
+					float snr = (float)chans[j]["squelch_snr_threshold"][f];
+					if (snr < 0) {
+						cerr << "Configuration error: devices.["<<i<<"] channels.["<<j<<"]: squelch_snr_threshold must be greater than or equal to 0\n";
+						error();
+					} else {
+						channel->freqlist[f].squelch.set_squelch_snr_threshold(snr);
+					}
+				}
+			} else if(libconfig::Setting::TypeFloat == chans[j]["squelch_snr_threshold"].getType()) {
+				// Legacy (single squelch for all frequencies)
+				float snr = (float)chans[j]["squelch_snr_threshold"];
+				if (snr < 0) {
+					cerr << "Configuration error: devices.["<<i<<"] channels.["<<j<<"]: squelch_snr_threshold must be greater than or equal to 0\n";
 					error();
 				}
 				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_value(sqlevel);
+					channel->freqlist[f].squelch.set_squelch_snr_threshold(snr);
 				}
 			} else {
-				cerr<<"Invalid value for squelch (should be int or list - use parentheses)\n";
-				error();
-			}
-		}
-		if(chans[j].exists("squelch_db")) {
-			if(libconfig::Setting::TypeList == chans[j]["squelch_db"].getType()) {
-				// New-style array of per-frequency squelch settings
-				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_db((float)chans[j]["squelch_db"][f]);
-				}
-			} else if(libconfig::Setting::TypeFloat == chans[j]["squelch_db"].getType()) {
-				// Legacy (single squelch for all frequencies)
-				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_db((float)chans[j]["squelch_db"]);
-				}
-			} else {
-				cerr << "Invalid value for squelch_db (should be float or list - use parentheses)\n";
-				error();
-			}
-		}
-		if(chans[j].exists("squelch_flappy_db")) {
-			if(libconfig::Setting::TypeList == chans[j]["squelch_flappy_db"].getType()) {
-				// New-style array of per-frequency squelch settings
-				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_flappy_db((float)chans[j]["squelch_flappy_db"][f]);
-				}
-			} else if(libconfig::Setting::TypeFloat == chans[j]["squelch_flappy_db"].getType()) {
-				// Legacy (single squelch for all frequencies)
-				for(int f = 0; f<channel->freq_count; f++) {
-					channel->freqlist[f].squelch.set_squelch_flappy_db((float)chans[j]["squelch_flappy_db"]);
-				}
-			} else {
-				cerr << "Invalid value for squelch_flappy_db (should be float or list - use parentheses)\n";
+				cerr << "Invalid value for squelch_snr_threshold (should be float or list - use parentheses)\n";
 				error();
 			}
 		}

--- a/config.cpp
+++ b/config.cpp
@@ -323,7 +323,7 @@ static int parse_channels(libconfig::Setting &chans, device_t *dev, int i) {
 			dev->input->centerfreq = channel->freqlist[0].frequency + 20 * (double)(dev->input->sample_rate / fft_size);
 		}
 		if(chans[j].exists("squelch")) {
-			cerr << "Warning: 'squelch' no longer supported and will be ignored, use 'squelch_level_threshold' or 'squelch_snr_threshold' instead\n";
+			cerr << "Warning: 'squelch' no longer supported and will be ignored, use 'squelch_threshold' or 'squelch_snr_threshold' instead\n";
 		}
 		if(chans[j].exists("squelch_threshold") && chans[j].exists("squelch_snr_threshold")) {
 			cerr << "Warning: Both 'squelch_threshold' and 'squelch_snr_threshold' are set and may conflict\n";

--- a/output.cpp
+++ b/output.cpp
@@ -570,7 +570,7 @@ static void print_channel_metric(FILE *f, char const *name, float freq, char *la
 }
 
 static void output_channel_noise_levels(FILE *f) {
-	fprintf(f, "# HELP channel_noise_level Squelch noise_floor.\n"
+	fprintf(f, "# HELP channel_noise_level Squelch noise_level.\n"
 			"# TYPE channel_noise_level gauge\n");
 
 	for (int i = 0; i < device_count; i++) {
@@ -579,7 +579,7 @@ static void output_channel_noise_levels(FILE *f) {
 			channel_t* channel = devices[i].channels + j;
 			for (int k = 0; k < channel->freq_count; k++) {
 				print_channel_metric(f, "channel_noise_level", channel->freqlist[k].frequency, channel->freqlist[k].label);
-				fprintf(f, "\t%.3f\n", channel->freqlist[k].squelch.noise_floor());
+				fprintf(f, "\t%.3f\n", channel->freqlist[k].squelch.noise_level());
 			}
 		}
 	}

--- a/output.cpp
+++ b/output.cpp
@@ -587,7 +587,7 @@ static void output_channel_noise_levels(FILE *f) {
 }
 
 static void output_channel_signal_levels(FILE *f) {
-	fprintf(f, "# HELP channel_signal_level Squelch power_level.\n"
+	fprintf(f, "# HELP channel_signal_level Squelch signal_level.\n"
 			"# TYPE channel_signal_level gauge\n");
 
 	for (int i = 0; i < device_count; i++) {
@@ -596,7 +596,7 @@ static void output_channel_signal_levels(FILE *f) {
 			channel_t* channel = devices[i].channels + j;
 			for (int k = 0; k < channel->freq_count; k++) {
 				print_channel_metric(f, "channel_signal_level", channel->freqlist[k].frequency, channel->freqlist[k].label);
-				fprintf(f, "\t%.3f\n", channel->freqlist[k].squelch.power_level());
+				fprintf(f, "\t%.3f\n", channel->freqlist[k].squelch.signal_level());
 			}
 		}
 	}

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -432,7 +432,7 @@ void *demodulate(void *params) {
 		}
 
 		if(dev->input->sfmt == SFMT_S16) {
-			float const scale = 127.5f / dev->input->fullscale;
+			float const scale = 1.0f / dev->input->fullscale;
 #ifdef USE_BCM_VC
 			struct GPU_FFT_COMPLEX *ptr = fft->in;
 			for(size_t b = 0; b < FFT_BATCH; b++, ptr += fft->step) {
@@ -450,7 +450,7 @@ void *demodulate(void *params) {
 			}
 #endif
 		} else if(dev->input->sfmt == SFMT_F32) {
-			float const scale = 127.5f / dev->input->fullscale;
+			float const scale = 1.0f / dev->input->fullscale;
 #ifdef USE_BCM_VC
 			struct GPU_FFT_COMPLEX *ptr = fft->in;
 			for(size_t b = 0; b < FFT_BATCH; b++, ptr += fft->step) {

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -651,17 +651,14 @@ void *demodulate(void *params) {
 					if(dev->mode == R_SCAN) {
 						GOTOXY(0, device_num * 17 + dev->row + 3);
 						// TODO: change to dB
-						printf("%4.0f/%3.0f%c %7.3f ",
-							fparms->squelch.power_level(),
-							fparms->squelch.squelch_level(),
+						printf("%8.3f%c %7.3f ",
+							fparms->squelch.current_snr(),
 							channel->axcindicate,
 							(dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					} else {
 						GOTOXY(i*10, device_num * 17 + dev->row + 3);
-						// TODO: change to dB
-						printf("%4.0f/%3.0f%c ",
-							fparms->squelch.power_level(),
-							fparms->squelch.squelch_level(),
+						printf("%8.3f%c ",
+							fparms->squelch.current_snr(),
 							channel->axcindicate);
 					}
 					fflush(stdout);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -651,14 +651,17 @@ void *demodulate(void *params) {
 					if(dev->mode == R_SCAN) {
 						GOTOXY(0, device_num * 17 + dev->row + 3);
 						// TODO: change to dB
-						printf("%8.3f%c %7.3f ",
-							fparms->squelch.current_snr(),
+						printf("%4.0f/%3.0f%c %7.3f ",
+							fparms->squelch.signal_level(),
+							fparms->squelch.squelch_level(),
 							channel->axcindicate,
 							(dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					} else {
 						GOTOXY(i*10, device_num * 17 + dev->row + 3);
-						printf("%8.3f%c ",
-							fparms->squelch.current_snr(),
+						// TODO: change to dB
+						printf("%4.0f/%3.0f%c ",
+							fparms->squelch.signal_level(),
+							fparms->squelch.squelch_level(),
 							channel->axcindicate);
 					}
 					fflush(stdout);

--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -349,10 +349,10 @@ void *demodulate(void *params) {
 	float *levels_ptr = NULL;
 
 	for (int i=0; i<256; i++) {
-		levels_u8[i] = i-127.5f;
+		levels_u8[i] = (i-127.5f)/127.5f;
 	}
 	for (int16_t i=-127; i<128; i++) {
-		levels_s8[(uint8_t)i] = i;
+		levels_s8[(uint8_t)i] = i/128.0f;
 	}
 
 	// initialize fft window
@@ -650,18 +650,16 @@ void *demodulate(void *params) {
 				if (tui) {
 					if(dev->mode == R_SCAN) {
 						GOTOXY(0, device_num * 17 + dev->row + 3);
-						// TODO: change to dB
 						printf("%4.0f/%3.0f%c %7.3f ",
-							fparms->squelch.signal_level(),
-							fparms->squelch.squelch_level(),
+							level_to_dBFS(fparms->squelch.signal_level()),
+							level_to_dBFS(fparms->squelch.noise_level()),
 							channel->axcindicate,
 							(dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					} else {
 						GOTOXY(i*10, device_num * 17 + dev->row + 3);
-						// TODO: change to dB
 						printf("%4.0f/%3.0f%c ",
-							fparms->squelch.signal_level(),
-							fparms->squelch.squelch_level(),
+							level_to_dBFS(fparms->squelch.signal_level()),
+							level_to_dBFS(fparms->squelch.noise_level()),
 							channel->axcindicate);
 					}
 					fflush(stdout);

--- a/rtl_airband.h
+++ b/rtl_airband.h
@@ -385,6 +385,8 @@ extern FILE *debugf;
 	do { if (DEBUG) fprintf(debugf, "%s(): " fmt, __func__, __VA_ARGS__); } while (0)
 #define XCALLOC(nmemb, size) xcalloc((nmemb), (size), __FILE__, __LINE__, __func__)
 #define XREALLOC(ptr, size) xrealloc((ptr), (size), __FILE__, __LINE__, __func__)
+float dBFS_to_level(const float &dBFS);
+float level_to_dBFS(const float &level);
 
 // mixer.cpp
 mixer_t *getmixerbyname(const char *name);

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -106,9 +106,6 @@ const float & Squelch::noise_level(void) const {
 }
 
 const float & Squelch::signal_level(void) const {
-	if (using_post_filter_) {
-		return post_filter_.full_;
-	}
 	return pre_filter_.full_;
 }
 

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -12,7 +12,7 @@ using namespace std;
 
 Squelch::Squelch(void)
 {
-	noise_floor_ = 15.0f;
+	noise_floor_ = 5.0f;
 	set_squelch_snr_threshold(9.54f); // depends on noise_floor_, sets using_manual_level_, normal_signal_ratio_, flappy_signal_ratio_, and moving_avg_cap_
 
 	pre_filter_ = {0.001f, 0.001f};
@@ -32,7 +32,7 @@ Squelch::Squelch(void)
 
 	delay_ = 0;
 	open_count_ = 0;
-	sample_count_ = 0;
+	sample_count_ = -1;
 	flappy_count_ = 0;
 	low_signal_count_ = 0;
 
@@ -396,7 +396,7 @@ void Squelch::calculate_noise_floor(void) {
 	static const float decay_factor = 0.97f;
 	static const float new_factor = 1.0 - decay_factor;
 
-	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 0.0001f;
+	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 0.00000001f;
 
 	// Need to update moving_avg_cap_ - depends on noise_floor_
 	calculate_moving_avg_cap();

--- a/squelch.h
+++ b/squelch.h
@@ -82,16 +82,16 @@ private:
 		float capped_;
 	};
 
+	float noise_floor_;			// noise level
 	bool using_manual_level_;	// if using a manually set signal level threshold
 	float manual_signal_level_;	// manually configured squelch level, < 0 for disabled
 	float normal_signal_ratio_;	// signal-to-noise ratio for normal squelch - ratio, not in dB
 	float flappy_signal_ratio_;	// signal-to-noise ratio for flappy squelch - ratio, not in dB
 
+	float moving_avg_cap_;		// the max value for capped moving average
 	MovingAverage pre_filter_;	// average signal level for reference sample
 	MovingAverage post_filter_;	// average signal level for post-filter sample
-	float moving_avg_cap_;		// the max value for capped moving average
 
-	float noise_floor_;			// noise level
 	float squelch_level_;		// cached calculation of the squelch_level() value
 
 	bool using_post_filter_;	// if the caller is providing filtered samples
@@ -125,7 +125,9 @@ private:
 	void set_state(State update);
 	void update_current_state(void);
 	bool has_signal(void);
-	void update_avg(MovingAverage &avg, const float &sample);
+	void calculate_noise_floor(void);
+	void calculate_moving_avg_cap(void);
+	void update_moving_avg(MovingAverage &avg, const float &sample);
 	bool currently_flapping(void) const;
 
 #ifdef DEBUG_SQUELCH

--- a/util.cpp
+++ b/util.cpp
@@ -211,7 +211,7 @@ float dBFS_to_level(const float &dBFS) {
 }
 
 float level_to_dBFS(const float &level) {
-	return 20.0f * log10f(level / fft_size) + dBFS_offet();
+	return std::min(0.0f, 20.0f * log10f(level / fft_size) + dBFS_offet());
 }
 
 // vim: ts=4

--- a/util.cpp
+++ b/util.cpp
@@ -195,4 +195,23 @@ double delta_sec(const timeval *start, const timeval *stop) {
 	return delta.tv_sec + delta.tv_usec/1000000.0;
 }
 
+// level to/from dBFS conversion assumes level is nomalized to 1 and is based on:
+//    https://kluedo.ub.uni-kl.de/frontdoor/deliver/index/docId/4293/file/exact_fft_measurements.pdf
+//
+// expanded form:
+//    20.0f * log10f(level / fft_size) + 7.54f + 10.0f * log10f(fft_size/2) - 2.38f
+
+const float &dBFS_offet(void) {
+	static const float offset = 7.54f + 10.0f * log10f(fft_size/2) - 2.38f;
+	return offset;
+}
+
+float dBFS_to_level(const float &dBFS) {
+	return pow(10.0, (dBFS - dBFS_offet()) / 20.0f) * fft_size;
+}
+
+float level_to_dBFS(const float &level) {
+	return 20.0f * log10f(level / fft_size) + dBFS_offet();
+}
+
 // vim: ts=4


### PR DESCRIPTION
Built on top of #230 with the addition of:
- Define squelch level as dB over noise
- Allow configuration of both normal and flappy squelch levels (in dB)
- Cache some calculations rather than re-calculating each time
- Change "signal power" to "signal level" - not actually measuring "power"