### PR TITLE
new waterfall char for signal outside of bandwidth

### DIFF
--- a/rtl_airband.cpp
+++ b/rtl_airband.cpp
@@ -648,19 +648,20 @@ void *demodulate(void *params) {
 #endif
 
 				if (tui) {
+					char symbol = fparms->squelch.signal_outside_filter() ? '~' : (char)channel->axcindicate;
 					if(dev->mode == R_SCAN) {
 						GOTOXY(0, device_num * 17 + dev->row + 3);
 						printf("%4.0f/%3.0f%c %7.3f ",
 							level_to_dBFS(fparms->squelch.signal_level()),
 							level_to_dBFS(fparms->squelch.noise_level()),
-							channel->axcindicate,
+							symbol,
 							(dev->channels[0].freqlist[channel->freq_idx].frequency / 1000000.0));
 					} else {
 						GOTOXY(i*10, device_num * 17 + dev->row + 3);
 						printf("%4.0f/%3.0f%c ",
 							level_to_dBFS(fparms->squelch.signal_level()),
 							level_to_dBFS(fparms->squelch.noise_level()),
-							channel->axcindicate);
+							symbol);
 					}
 					fflush(stdout);
 				}

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -88,8 +88,8 @@ bool Squelch::is_open(void) const {
 	return (current_state_ == OPEN || current_state_ == CLOSING);
 }
 
-bool Squelch::should_filter_sample(void) const {
-	return (current_state_ != CLOSED && current_state_ != LOW_SIGNAL_ABORT);
+bool Squelch::should_filter_sample(void) {
+	return ((has_pre_filter_signal() || current_state_ != CLOSED) && current_state_ != LOW_SIGNAL_ABORT);
 }
 
 bool Squelch::first_open_sample(void) const {
@@ -101,20 +101,16 @@ bool Squelch::last_open_sample(void) const {
 		   (current_state_ != LOW_SIGNAL_ABORT && next_state_ == LOW_SIGNAL_ABORT);
 }
 
+bool Squelch::signal_outside_filter(void) {
+	return (using_post_filter_ && has_pre_filter_signal() && !has_post_filter_signal());
+}
+
 const float & Squelch::noise_level(void) const {
 	return noise_floor_;
 }
 
 const float & Squelch::signal_level(void) const {
 	return pre_filter_.full_;
-}
-
-const size_t & Squelch::open_count(void) const {
-	return open_count_;
-}
-
-const size_t & Squelch::flappy_count(void) const {
-	return flappy_count_;
 }
 
 const float & Squelch::squelch_level(void) {
@@ -130,6 +126,14 @@ const float & Squelch::squelch_level(void) {
 		}
 	}
 	return squelch_level_;
+}
+
+const size_t & Squelch::open_count(void) const {
+	return open_count_;
+}
+
+const size_t & Squelch::flappy_count(void) const {
+	return flappy_count_;
 }
 
 void Squelch::process_raw_sample(const float &sample) {
@@ -382,11 +386,19 @@ void Squelch::update_current_state(void) {
 #endif
 }
 
+bool Squelch::has_pre_filter_signal(void) {
+	return pre_filter_.capped_ >= squelch_level();
+}
+
+bool Squelch::has_post_filter_signal(void) {
+	return using_post_filter_ && post_filter_.capped_ >= buffer_[buffer_tail_];
+}
+
 bool Squelch::has_signal(void) {
 	if (using_post_filter_) {
-		return pre_filter_.capped_ >= squelch_level() && post_filter_.capped_ >= buffer_[buffer_tail_];
+		return has_pre_filter_signal() && has_post_filter_signal();
 	}
-	return pre_filter_.capped_ >= squelch_level();
+	return has_pre_filter_signal();
 }
 
 void Squelch::calculate_noise_floor(void) {

--- a/squelch.cpp
+++ b/squelch.cpp
@@ -154,7 +154,7 @@ void Squelch::process_raw_sample(const float &sample) {
 	//    slowly increasing during a long signal.
 	// TODO: is there an issue not updating noise floor when squelch is open?  Mabye a sharp
 	//       increase in noise causing squelch to open and never close?
-	if (sample_count_ % 16 == 0 && !is_open()) {
+	if (sample_count_ % 16 == 0 && !is_open() && !signal_outside_filter()) {
 		calculate_noise_floor();
 	}
 

--- a/squelch.h
+++ b/squelch.h
@@ -51,17 +51,19 @@ public:
 	void process_filtered_sample(const float &sample);
 
 	bool is_open(void) const;
-	bool should_filter_sample(void) const;
+	bool should_filter_sample(void);
 
 	bool first_open_sample(void) const;
 	bool last_open_sample(void) const;
+	bool signal_outside_filter(void);
 
 	const float & noise_level(void) const;
 	const float & signal_level(void) const;
+	const float & squelch_level(void);
 
 	const size_t & open_count(void) const;
 	const size_t & flappy_count(void) const;
-	const float & squelch_level(void);
+
 
 #ifdef DEBUG_SQUELCH
 	~Squelch(void);
@@ -124,6 +126,8 @@ private:
 
 	void set_state(State update);
 	void update_current_state(void);
+	bool has_pre_filter_signal(void);
+	bool has_post_filter_signal(void);
 	bool has_signal(void);
 	void calculate_noise_floor(void);
 	void calculate_moving_avg_cap(void);


### PR DESCRIPTION
A raw signal level can cross the squelch threshold, but if a bandwidth filter is configure and removes too much of that signal (ie no signal post-filter), the squelch will remain CLOSED.  This change introduces a new waterfall character `~` to indicate when this is happening.

See image below showing the same recording of a 5 kHz signal playing through two "devices" with an FFT size of 1024 and  both devices having multiple channels at 7.5 kHz spacing.  The first "device" has bandwidth on each channel set at 5 kHz and the second "device" has no bandwidth configured.  Power levels between the two devices are shown as the same.  On the two immediate side channels the "with bandwidth" device has squelch closed and showing the new character while the "without bandwidth" device shows squelch open.

<img width="487" alt="Screen Shot 2021-03-26 at 12 20 38 PM" src="https://user-images.githubusercontent.com/13514783/112683036-35f7bc80-8e2e-11eb-8a7a-10ec83eff865.png">
