### PR TITLE
 Noise floor doesnt raise

### DIFF
--- a/src/squelch.cpp
+++ b/src/squelch.cpp
@@ -405,7 +405,7 @@ void Squelch::calculate_noise_floor(void) {
 	static const float decay_factor = 0.97f;
 	static const float new_factor = 1.0 - decay_factor;
 
-	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 0.00000003f;
+	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 1e-6f;
 
 	// Need to update moving_avg_cap_ - depends on noise_floor_
 	calculate_moving_avg_cap();

--- a/src/squelch.cpp
+++ b/src/squelch.cpp
@@ -405,7 +405,7 @@ void Squelch::calculate_noise_floor(void) {
 	static const float decay_factor = 0.97f;
 	static const float new_factor = 1.0 - decay_factor;
 
-	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 0.00000001f;
+	noise_floor_ = noise_floor_ * decay_factor + std::min(pre_filter_.capped_, noise_floor_) * new_factor + 0.00000003f;
 
 	// Need to update moving_avg_cap_ - depends on noise_floor_
 	calculate_moving_avg_cap();


### PR DESCRIPTION
Change the noise_floor increase from `0.00000001f` to `0.00000003f`.  It appears that smaller values are optimized out somewhere (I tried disabling `fast-math` and that wasn't it)