### PR TITLE
add option to include frequency in Hz in output filenames

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -87,6 +87,8 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 			fdata->append = (!outs[o].exists("append")) || (bool)(outs[o]["append"]);
 			fdata->split_on_transmission = outs[o].exists("split_on_transmission") ?
 				(bool)(outs[o]["split_on_transmission"]) : false;
+			fdata->include_freq_in_filename = outs[o].exists("include_freq_in_filename") ?
+				(bool)(outs[o]["include_freq_in_filename"]) : false;
 			channel->need_mp3 = 1;
 
 			if(fdata->split_on_transmission) {
@@ -131,6 +133,8 @@ static int parse_outputs(libconfig::Setting &outs, channel_t *channel, int i, in
 			fdata->append = (!outs[o].exists("append")) || (bool)(outs[o]["append"]);
 			fdata->split_on_transmission = outs[o].exists("split_on_transmission") ?
 				(bool)(outs[o]["split_on_transmission"]) : false;
+			fdata->include_freq_in_filename = outs[o].exists("include_freq_in_filename") ?
+				(bool)(outs[o]["include_freq_in_filename"]) : false;
 			channel->needs_raw_iq = channel->has_iq_outputs = 1;
 
 			if(fdata->continuous && fdata->split_on_transmission) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -403,13 +403,18 @@ static bool output_file_ready(channel_t *channel, file_data *fdata, mix_modes mi
 		log(LOG_NOTICE, "strftime returned 0\n");
 		return false;
 	}
-	size_t file_path_len = strlen(fdata->basename) + strlen(timestamp) + strlen(fdata->suffix) + 1;
+
+	size_t file_path_len = strlen(fdata->basename) + strlen(timestamp) + strlen(fdata->suffix) + 11; // include space for '\0' and possible freq in Hz
 	fdata->file_path = (char *)XCALLOC(1, file_path_len);
-	sprintf(fdata->file_path, "%s%s%s", fdata->basename, timestamp, fdata->suffix);
+	if (fdata->include_freq_in_filename) {
+		sprintf(fdata->file_path, "%s_%d%s%s", fdata->basename, channel->freqlist[channel->freq_idx].frequency, timestamp, fdata->suffix);
+	} else {
+		sprintf(fdata->file_path, "%s%s%s", fdata->basename, timestamp, fdata->suffix);
+	}
 
 	static char const *tmp_suffix = ".tmp";
 	fdata->file_path_tmp = (char *)XCALLOC(1, file_path_len + strlen(tmp_suffix));
-	sprintf(fdata->file_path_tmp, "%s%s%s%s", fdata->basename, timestamp, fdata->suffix, tmp_suffix);
+	sprintf(fdata->file_path_tmp, "%s%s", fdata->file_path, tmp_suffix);
 
 	fdata->open_time = fdata->last_write_time = current_time;
 

--- a/src/rtl_airband.h
+++ b/src/rtl_airband.h
@@ -144,6 +144,7 @@ struct file_data {
 	bool continuous;
 	bool append;
 	bool split_on_transmission;
+	bool include_freq_in_filename;
 	timeval open_time;
 	timeval last_write_time;
 	FILE *f;


### PR DESCRIPTION
Add config option `include_freq_in_filename` that, if set, will include the channel frequency in output filenames before the timestamp.

Example output filenames based on parameters:

`include_freq_in_filename = false` and `split_on_transmission = false`:
> test_20210905_23.mp3

`include_freq_in_filename = false` and `split_on_transmission = true`:
> test_20210905_235319.mp3
> test_20210905_235323.mp3

`include_freq_in_filename = true ` and `split_on_transmission = false`:
> test_150145000_20210905_23.mp3

`include_freq_in_filename = true` and `split_on_transmission = true `:
> test_150145000_20210905_235319.mp3
> test_150145000_20210905_235323.mp3


