### PR TITLE
Add -rdynamic to CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT CMAKE_BUILD_TYPE)
    message(STATUS "Build type not specified: defaulting to Release")
 endif(NOT CMAKE_BUILD_TYPE)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -rdynamic -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og -DDEBUG")
 
 if(DEBUG_SQUELCH)


### PR DESCRIPTION
Make sure that exported functions (i.e. {device}_input_new()) will land in the dynamic symbol table, regardless of level of optimization.

I experienced missing symbols using GCC 10.3.1 with Buildroot. This option has been available since GCC 4.1.0.