### PR TITLE
Set ENABLE_EXPORTS property for rtl_airband

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -285,6 +285,7 @@ link_directories(${link_dirs})
 list(APPEND rtl_airband_obj_files $<TARGET_OBJECTS:rtl_airband_base>)
 
 add_executable (rtl_airband ${rtl_airband_obj_files})
+set_property(TARGET rtl_airband PROPERTY ENABLE_EXPORTS 1)
 
 target_link_libraries (rtl_airband
 	dl


### PR DESCRIPTION
Make sure that exported functions (i.e. {device}_input_new()) will land in the dynamic symbol table, regardless of level of optimization.

I experienced missing symbols using GCC (10.3.1) with Buildroot (2022-11-rc2). That build environment doesn't leverage the "historical" implicit exporting enabled on other distros through the following module:

    /usr/share/cmake-{cmake-version}/Modules/Platform/Linux-GNU.cmake

---

This is an improved implementation superseding #338 