### PR TITLE
Drop macos-13 from CI

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -13,7 +13,7 @@ jobs:
   ci_build:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-13, macos-14, ubuntu-22.04-arm ]
+        os: [ ubuntu-22.04, macos-14, ubuntu-22.04-arm ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 35 # runtime across all OSs, runs can get queued
     steps:


### PR DESCRIPTION
remove macos-13 from CI - github runner no longer supported

I am making my contributions to this project solely in my personal capacity and am not conveying any rights to any intellectual property of any third parties.